### PR TITLE
Stream: flipped arguments of lines_to_channel

### DIFF
--- a/src/lib/biocaml_stream.ml
+++ b/src/lib/biocaml_stream.ml
@@ -462,7 +462,7 @@ let lines_of_channel cin =
     with End_of_file -> None
   in Stream.from f
 
-let lines_to_channel oc xs =
+let lines_to_channel xs oc =
   iter
     xs
     ~f:(fun l -> output_string oc l ; output_char oc '\n')

--- a/src/lib/biocaml_stream.mli
+++ b/src/lib/biocaml_stream.mli
@@ -216,7 +216,7 @@ val range : ?until:int -> int -> int t
 
 val lines_of_chars : char t -> string t
 val lines_of_channel : in_channel -> string Stream.t
-val lines_to_channel : out_channel -> string Stream.t -> unit
+val lines_to_channel : string Stream.t -> out_channel -> unit
 
 val to_list : 'a t -> 'a list
 val result_to_exn :


### PR DESCRIPTION
this order is more convenient to use Core.Std.Out_channel.with_file
