### PR TITLE
fasta: added char_seq_items_to_out_channel function

### DIFF
--- a/src/lib/biocaml_fasta.ml
+++ b/src/lib/biocaml_fasta.ml
@@ -445,3 +445,11 @@ let in_channel_to_int_seq_item_stream_exn ?(buffer_size=65536) ?filename
   Stream.result_to_exn ~error_to_exn (
     in_channel_to_int_seq_item_stream ?filename ?tags inp
   )
+
+let char_seq_items_to_out_channel ?tags items oc =
+  let t =
+    Biocaml_transform.compose
+      (Transform.char_seq_item_to_raw_item ?tags ())
+      (Transform.char_seq_raw_item_to_string ?tags ())
+  in
+  Biocaml_transform.stream_to_out_channel items t oc

--- a/src/lib/biocaml_fasta.mli
+++ b/src/lib/biocaml_fasta.mli
@@ -198,6 +198,13 @@ val in_channel_to_int_seq_item_stream_exn :
 (** Returns a stream of [int_seq item]s. Comments are
     discarded.  [Stream.next] will raise [Error _] in case of any error. *)
 
+(** {2 [Out_channel] Functions } *)
+
+val char_seq_items_to_out_channel :
+  ?tags:Tags.t ->
+  char_seq item Stream.t ->
+  out_channel ->
+  unit
 
 (** {2 Raw Items}
 

--- a/src/lib/biocaml_transform.ml
+++ b/src/lib/biocaml_transform.ml
@@ -75,6 +75,9 @@ let to_stream_fun tr en =
 let in_channel_strings_to_stream ?(buffer_size=65536) ic tr =
   to_stream_fun tr (Stream.strings_of_channel ~buffer_size ic)
 
+let stream_to_out_channel xs tr oc =
+  Stream.iter (to_stream_fun tr xs) ~f:(output_string oc)
+
 let on_input t ~f =
   { t with feed = fun x -> t.feed (f x) }
 

--- a/src/lib/biocaml_transform.mli
+++ b/src/lib/biocaml_transform.mli
@@ -99,6 +99,11 @@ val to_stream_fun:
 val in_channel_strings_to_stream :
   ?buffer_size:int -> in_channel -> (string, 'output) t -> 'output Stream.t
 
+(** [stream_to_out_channel xs t oc] consumes a stream of ['input]s
+    using [t] to transform them into strings, which are then written
+    on the out_channel [oc]. *)
+val stream_to_out_channel :
+  'input Stream.t -> ('input, string) t -> out_channel ->  unit
 
 (** {2 Compose}
 


### PR DESCRIPTION
I refrained from committing directly because I touched the transform module, but this is merely what we discussed on the list. If this is ok, I'll commit directly when I need other such functions.
Thanks!
