### PR TITLE
Suppress the dependency on pcre (fix #56)

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -35,7 +35,7 @@ LIB_MODULES[] =
   $(removesuffix $(basename $(ls src/lib/*.ml)))
   $(PROJECT)_about
 LIB_STUBS = $(PROJECT)_pwm_stub $(PROJECT)_mzData_stubs
-LIB_PACKAGES = core threads zip unix xmlm pcre cfstream sexplib.syntax future.std
+LIB_PACKAGES = core threads zip unix xmlm cfstream sexplib.syntax future.std
 
 LIB_LWT_NAME = $(PROJECT)_lwt
 LIB_LWT_MODULES[] =

--- a/bin/travis.sh
+++ b/bin/travis.sh
@@ -28,7 +28,6 @@ opam install \
   omake \
   camlzip \
   xmlm \
-  pcre-ocaml \
   core.$CORE_VERSION \
   cfstream \
   lwt \

--- a/etc/opam/packages/biocaml.master/opam
+++ b/etc/opam/packages/biocaml.master/opam
@@ -25,7 +25,6 @@ depends: [
   "sexplib"
   "camlzip"
   "xmlm"
-  "pcre-ocaml"
   "omake"
   "cfstream"
   "future"

--- a/src/lib/biocaml_jaspar.mli
+++ b/src/lib/biocaml_jaspar.mli
@@ -1,5 +1,4 @@
-(** Jaspar data. *)
-open Biocaml_internal_pervasives
+(** Access to Jaspar database *)
 
 (** The possible kinds of motifs. *)
 type collection =
@@ -7,20 +6,19 @@ type collection =
 
 type motif = private {
   id : string ;
+  jaspar_id : string ;
   collection : collection ;
   factor_name : string ;
   factor_class : string ;
-  information_contents : float ;
+  family : string option ;
   comment : string option ;
-  accession : string option ;
   medline : string ;
   matrix : int array array ;
 }
-(** The main “Jaspar element”. *)
+(** A Jaspar motif *)
 
 val load : string -> motif list
-(** Load a [motif list] from a given [path] (reading file [path ^
-    "/matrix_list.txt"]). *)
+(** Loads a database in SQL dump format, as available at {{:http://jaspar.genereg.net/html/DOWNLOAD/database/}Jaspar website} *)
 
 
 

--- a/src/top/biocaml_toplevel.ml
+++ b/src/top/biocaml_toplevel.ml
@@ -27,7 +27,7 @@ let () =
     fprintf o "
 #use \"topfind\";;
 #thread;;
-#require \"core, zip, sqlite3, unix, batteries, xmlm, pcre\"
+#require \"core, zip, sqlite3, unix, batteries, xmlm\"
 #directory %S;;
 #load \"biocaml.cma\";;
 open Core.Std;;


### PR DESCRIPTION
The last (only?) module using pcre was Jaspar. When trying to remove
the use of pcre in this module, I noticed the layout of the database
had recently been significantly changed. So I rewrote the whole
module, taking care of not using pcre this time. I also removed all
occurrences of pcre in the various configuration scripts.

Last point: I wrote a test for the parser, but to run it with other
unit tests I need a chunk of jaspar, and for licensing issues I
suppose it is not allowed to include a part of jaspar in the biocaml
distribution. So the unit test is not included in this patch.
