### PR TITLE
sam: expose header parsing for reuse in bam parsers

### DIFF
--- a/src/lib/biocaml_sam.ml
+++ b/src/lib/biocaml_sam.ml
@@ -946,7 +946,7 @@ module MakeIO(Future : Future.S) = struct
   open Future
   module Lines = Biocaml_lines.MakeIO(Future)
 
-  let read ?(start=Pos.(incr_line unknown)) r =
+  let read_header lines =
     let init_hdr = {
       version = None;
       sort_order = None;
@@ -957,15 +957,6 @@ module MakeIO(Future : Future.S) = struct
       others = [];
     }
     in
-
-    let pos = ref start in
-    let lines =
-      Pipe.map (Lines.read r) ~f:(fun line ->
-        pos := Pos.incr_line !pos;
-        line
-      )
-    in
-
     let rec loop hdr : header Or_error.t Deferred.t =
       Pipe.peek_deferred lines >>= (function
       | `Eof -> return (Ok hdr)
@@ -993,30 +984,38 @@ module MakeIO(Future : Future.S) = struct
         )
       )
     in
-
     loop init_hdr >>| function
-    | Error _ as e -> Or_error.tag_arg e "position" !pos Pos.sexp_of_t
+    | Error _ as e -> e
     | Ok ({version; sort_order; _} as x) ->
       let ref_seqs = List.rev x.ref_seqs in
       let read_groups = List.rev x.read_groups in
       let programs = List.rev x.programs in
       let comments = List.rev x.comments in
       let others = List.rev x.others in
-      let hdr =
-        header
-          ?version ?sort_order ~ref_seqs ~read_groups
-          ~programs ~comments ~others ()
-      in
-      match hdr with
-      | Error _ as e -> Or_error.tag_arg e "position" !pos Pos.sexp_of_t
-      | Ok hdr ->
-        let alignments = Pipe.map lines ~f:(fun line ->
+      header
+        ?version ?sort_order ~ref_seqs ~read_groups
+        ~programs ~comments ~others ()
+
+
+  let read ?(start=Pos.(incr_line unknown)) r =
+    let pos = ref start in
+    let lines =
+      Pipe.map (Lines.read r) ~f:(fun line ->
+        pos := Pos.incr_line !pos;
+        line
+      )
+    in
+
+    read_header lines >>| function
+    | Error _ as e -> Or_error.tag_arg e "position" !pos Pos.sexp_of_t
+    | Ok hdr ->
+      let alignments = Pipe.map lines ~f:(fun line ->
           Or_error.tag_arg
             (parse_alignment line)
             "position" !pos Pos.sexp_of_t
         )
-        in
-        Ok (hdr, alignments)
+      in
+      Ok (hdr, alignments)
 
 
   let read_file ?buf_len file =
@@ -1063,3 +1062,6 @@ module MakeIO(Future : Future.S) = struct
 
 end
 include MakeIO(Future_std)
+
+let parse_header text =
+  read_header (Biocaml_lines.of_string text)

--- a/src/lib/biocaml_sam.mli
+++ b/src/lib/biocaml_sam.mli
@@ -286,7 +286,7 @@ val parse_platform : string -> platform Or_error.t
 val parse_read_group : tag_value list -> read_group Or_error.t
 val parse_program : tag_value list -> program Or_error.t
 val parse_header_item : Line.t -> header_item Or_error.t
-
+val parse_header : string -> header Or_error.t
 
 
 (******************************************************************************)


### PR DESCRIPTION
It happens that BAM files carry the SAM header in plain text, so it would be useful to reuse the code from the `Sam` module. I tried my best to expose the function without breaking anything, but I'd rather have @agarwal have a look at it before pushing it on the repo.
