### PR TITLE
Simple edit distance algorithm.

### DIFF
--- a/src/lib/biocaml_algo_edit_distance.ml
+++ b/src/lib/biocaml_algo_edit_distance.ml
@@ -1,0 +1,35 @@
+(** Simple calculation of edit distance bitween 2 strings. Only three 
+    operations: Insert, Delete and Substitue are taken into account. 
+    All the operations have the same weight equal to 1. The first and 
+    the second parameters are the strings to compare.
+
+    This is a standard dynamic programming algorithm that requires 
+    (min m n) memory and m*n time (m and n are the lengths of the strings 
+    to compare).
+*)
+let simpleEditDistance t s =
+  let s, m, t, n =
+    let m, n = String.length s, String.length t in
+    if m < n then
+      s, m, t, n
+    else
+      t, n, s, m
+  in (* now s is not larger than t and m <= n *)
+  let d = Array.init (m + 1) (fun i -> i) in
+
+  (* 3 argument min function (uses 2 arg standard min) *)
+  let min a b c = min a (min b c) in
+  for j = 1 to n do
+    d.(0) <- j;
+    let diag = ref (j - 1) in
+
+    for i = 1 to m do
+      let old = d.(i) in
+      let diag_cost = if s.[i - 1] = t.[j - 1] then 0 else 1 in
+      d.(i) <- min (old + 1) (d.(i - 1) + 1) (!diag + diag_cost);
+
+      diag := old
+    done;
+  done;
+  d.(m)
+;;

--- a/src/tests/main.ml
+++ b/src/tests/main.ml
@@ -1,6 +1,7 @@
 open OUnit
 
 let all_tests = [
+  Test_algo.tests;
   Test_lines.tests;
   Test_bgzf.tests;
   Test_bam.tests;

--- a/src/tests/test_algo.ml
+++ b/src/tests/test_algo.ml
@@ -1,0 +1,21 @@
+open OUnit
+open Biocaml_algo_edit_distance
+
+let test_simple_edit_distance () =
+  assert_bool
+    "simple edit distance test failed"
+    (
+      let editDistanceTestList = 
+      [("ISLANDER", "SLANDER", 1); ("MART", "KARMA", 3);
+       ("KITTEN", "SITTING", 3); ("INTENTION", "EXECUTION", 5);
+       ("PLEASANTLY", "MEANLY", 5)]
+      in
+      List.fold_left
+        (fun result (a, b, distance) -> 
+          result && (distance = (simpleEditDistance a b))
+        ) true editDistanceTestList
+    )
+
+let tests = "Algo" >::: [
+  "simple edit distance" >:: test_simple_edit_distance;
+]


### PR DESCRIPTION
Thanks for comments. This is a corrected version of the code.

Here the goal was to make as simple as possible function that can be used to verify more complicated algorithms that I'll introduce later. Therefore I didn't include the cost function. However, reducing memory cost is important, since all the data will stay in CPU cache. Thanks again for comments - I forgot about this optimization.

Another question - what it the best name for the module? Later I'll introduce several alignment algorithms, which will construct backtrace and calculate edit distance based on it. Should it be the separate module (say biocaml_algo_alignment) or the same?