### PR TITLE
enable strict warnings, open modules inside jbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 
 .PHONY: test
 test:
-	jbuilder build @runtest --dev -j 1
+	jbuilder build @runtest --dev
 
 doc:
 	make doc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all
+all:
+	jbuilder build --dev @install
+	jbuilder build --dev @runtest
+
+.PHONY: clean
+clean:
+	jbuilder clean
+
+.PHONY: test
+test:
+	jbuilder build @runtest --dev -j 1
+
+doc:
+	make doc
+

--- a/app/biocaml_run_benchmarks.ml
+++ b/app/biocaml_run_benchmarks.ml
@@ -1,4 +1,3 @@
-open Core.Std
 open Biocaml_unix.Std
 open Biocaml_benchmark
 

--- a/app/jbuild
+++ b/app/jbuild
@@ -3,6 +3,7 @@
 (executable
  ((name biocaml_run_tests)
   (libraries (biocaml_test))
+  (flags (-open Core))
   ))
 
 (alias

--- a/app/jbuild
+++ b/app/jbuild
@@ -3,7 +3,7 @@
 (executable
  ((name biocaml_run_tests)
   (libraries (biocaml_test))
-  (flags (-open Core))
+  (flags (:standard -short-paths -open Core))
   ))
 
 (alias

--- a/lib/async/future_async.ml
+++ b/lib/async/future_async.ml
@@ -1,5 +1,5 @@
-open Core
-open Async
+
+
 
 type how = Monad_sequence.how
 
@@ -68,7 +68,7 @@ module Unix = struct
   (* let getpid = Unix.getpid *)
 
   module Stats = struct
-    type t = Core.Unix.stats = {
+    type _t = Core.Unix.stats = {
       st_dev   : int;
       st_ino   : int;
       st_kind  : Core.Unix.file_kind;

--- a/lib/async/future_async.mli
+++ b/lib/async/future_async.mli
@@ -1,6 +1,4 @@
-open Core
 open Async
-
 include Biocaml_unix.Future.S
   with type 'a Deferred.t = 'a Deferred.t
   and type 'a Pipe.Reader.t = 'a Pipe.Reader.t

--- a/lib/async/future_async.mli
+++ b/lib/async/future_async.mli
@@ -1,4 +1,3 @@
-open Async
 include Biocaml_unix.Future.S
   with type 'a Deferred.t = 'a Deferred.t
   and type 'a Pipe.Reader.t = 'a Pipe.Reader.t

--- a/lib/async/jbuild
+++ b/lib/async/jbuild
@@ -7,6 +7,7 @@
   (preprocess (pps (ppx_jane)))
   (flags (
     :standard
+    -short-paths
     -open Core
     -open Async
   ))

--- a/lib/async/jbuild
+++ b/lib/async/jbuild
@@ -5,5 +5,10 @@
   (public_name biocaml.async)
   (libraries (biocaml.unix async))
   (preprocess (pps (ppx_jane)))
+  (flags (
+    :standard
+    -open Core
+    -open Async
+  ))
   (optional)
   ))

--- a/lib/base/bed.ml
+++ b/lib/base/bed.ml
@@ -1,4 +1,3 @@
-open Base
 
 type parser_error = [ `Bed_parser_error of int * string ]
 [@@deriving sexp]

--- a/lib/base/bed.mli
+++ b/lib/base/bed.mli
@@ -3,7 +3,7 @@ type parser_error = [ `Bed_parser_error of int * string ]
 
 type item = string * int * int * string list
 
-val item_of_line : Line.t -> (item, string) result
+val item_of_line : Line.t -> (item, string) Caml.result
 val line_of_item : item -> Line.t
 
 module Bed3 : sig
@@ -46,11 +46,11 @@ module Bed5_raw : sig
     name:string ->
     score:int ->
     ?others:string list ->
-    unit -> (item, string) result
+    unit -> (item, string) Caml.result
 
   val set_score : item -> int -> item
 
-  val item_of_line : Line.t -> (item, string) result
+  val item_of_line : Line.t -> (item, string) Caml.result
   val line_of_item : item -> Line.t
 end
 
@@ -65,8 +65,8 @@ module Bed5 : sig
     name:string ->
     score:int ->
     ?others:string list ->
-    unit -> (item, string) result
+    unit -> (item, string) Caml.result
 
-  val item_of_line : Line.t -> (item, string) result
+  val item_of_line : Line.t -> (item, string) Caml.result
   val line_of_item : item -> Line.t
 end

--- a/lib/base/bed.mli
+++ b/lib/base/bed.mli
@@ -3,7 +3,7 @@ type parser_error = [ `Bed_parser_error of int * string ]
 
 type item = string * int * int * string list
 
-val item_of_line : Line.t -> (item, string) Caml.result
+val item_of_line : Line.t -> (item, string) Result.t
 val line_of_item : item -> Line.t
 
 module Bed3 : sig
@@ -46,11 +46,11 @@ module Bed5_raw : sig
     name:string ->
     score:int ->
     ?others:string list ->
-    unit -> (item, string) Caml.result
+    unit -> (item, string) Result.t
 
   val set_score : item -> int -> item
 
-  val item_of_line : Line.t -> (item, string) Caml.result
+  val item_of_line : Line.t -> (item, string) Result.t
   val line_of_item : item -> Line.t
 end
 
@@ -65,8 +65,8 @@ module Bed5 : sig
     name:string ->
     score:int ->
     ?others:string list ->
-    unit -> (item, string) Caml.result
+    unit -> (item, string) Result.t
 
-  val item_of_line : Line.t -> (item, string) Caml.result
+  val item_of_line : Line.t -> (item, string) Result.t
   val line_of_item : item -> Line.t
 end

--- a/lib/base/fasta.ml
+++ b/lib/base/fasta.ml
@@ -1,6 +1,5 @@
 (* FIXME: max_line_length and alphabet format options are not implemented *)
 
-open Base
 open Rresult
 
 type header = string list

--- a/lib/base/fasta.mli
+++ b/lib/base/fasta.mli
@@ -112,7 +112,7 @@ val fmt :
 val default_fmt : fmt
 
 (** Parse a space separated list of integers. *)
-val sequence_to_int_list : string -> (int list, [> `Msg of string]) result
+val sequence_to_int_list : string -> (int list, [> `Msg of string]) Caml.result
 
 
 (** An [item0] is more raw than [item]. It is useful for parsing files
@@ -159,7 +159,7 @@ module Parser0 : sig
   val step :
     state ->
     string option ->
-    (state * item0 list, [> parser_error]) result
+    (state * item0 list, [> parser_error]) Caml.result
 end
 
 val unparser0 : item0 -> string
@@ -178,7 +178,7 @@ module Parser : sig
   val step :
     state ->
     string option ->
-    (state * item list, [> parser_error]) result
+    (state * item list, [> parser_error]) Caml.result
 end
 
 val unparser : item -> string

--- a/lib/base/fasta.mli
+++ b/lib/base/fasta.mli
@@ -112,7 +112,7 @@ val fmt :
 val default_fmt : fmt
 
 (** Parse a space separated list of integers. *)
-val sequence_to_int_list : string -> (int list, [> `Msg of string]) Caml.result
+val sequence_to_int_list : string -> (int list, [> `Msg of string]) Result.t
 
 
 (** An [item0] is more raw than [item]. It is useful for parsing files
@@ -159,7 +159,7 @@ module Parser0 : sig
   val step :
     state ->
     string option ->
-    (state * item0 list, [> parser_error]) Caml.result
+    (state * item0 list, [> parser_error]) Result.t
 end
 
 val unparser0 : item0 -> string
@@ -178,7 +178,7 @@ module Parser : sig
   val step :
     state ->
     string option ->
-    (state * item list, [> parser_error]) Caml.result
+    (state * item list, [> parser_error]) Result.t
 end
 
 val unparser : item -> string

--- a/lib/base/gff.ml
+++ b/lib/base/gff.ml
@@ -1,6 +1,6 @@
 (* https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md *)
 
-open Base
+
 open Printf
 
 type record = {

--- a/lib/base/gff.ml
+++ b/lib/base/gff.ml
@@ -1,8 +1,5 @@
 (* https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md *)
 
-
-open Printf
-
 type record = {
   seqname    : string ;
   source     : string option ;

--- a/lib/base/gff.mli
+++ b/lib/base/gff.mli
@@ -49,5 +49,5 @@ val record :
   ?attributes:(string * string list) list ->
   string -> int -> int -> record
 
-val gff3_item_of_line : Line.t -> (item, [> `Msg of string]) result
+val gff3_item_of_line : Line.t -> (item, [> `Msg of string]) Caml.result
 val line_of_item : [`two | `three] -> item -> Line.t

--- a/lib/base/gff.mli
+++ b/lib/base/gff.mli
@@ -49,5 +49,5 @@ val record :
   ?attributes:(string * string list) list ->
   string -> int -> int -> record
 
-val gff3_item_of_line : Line.t -> (item, [> `Msg of string]) Caml.result
+val gff3_item_of_line : Line.t -> (item, [> `Msg of string]) Result.t
 val line_of_item : [`two | `three] -> item -> Line.t

--- a/lib/base/jbuild
+++ b/lib/base/jbuild
@@ -10,6 +10,5 @@
     -short-paths
     -open Base
     -open Printf
-    -open Biocaml_base
   ))
   (preprocess (pps (ppx_sexp_conv ppx_inline_test)))))

--- a/lib/base/jbuild
+++ b/lib/base/jbuild
@@ -5,4 +5,9 @@
   (public_name biocaml.base)
   (libraries (base rresult uri))
   (inline_tests)
+  (flags (
+    :standard
+    -open Base
+    -open Biocaml_base
+  ))
   (preprocess (pps (ppx_sexp_conv ppx_inline_test)))))

--- a/lib/base/jbuild
+++ b/lib/base/jbuild
@@ -7,7 +7,9 @@
   (inline_tests)
   (flags (
     :standard
+    -short-paths
     -open Base
+    -open Printf
     -open Biocaml_base
   ))
   (preprocess (pps (ppx_sexp_conv ppx_inline_test)))))

--- a/lib/base/line.ml
+++ b/lib/base/line.ml
@@ -1,4 +1,4 @@
-open Base
+
 
 type t = string [@@deriving sexp]
 

--- a/lib/base/lines.ml
+++ b/lib/base/lines.ml
@@ -12,7 +12,7 @@ module Parser = struct
 
   let line_number = function
     | Current_line { n ; value } ->
-      if (value :> string) = "" then n else n + 1
+      if (String.equal (value :> string) "") then n else n + 1
     | Finished { n } -> n
 
   let step st i = match st, i with

--- a/lib/base/macs2.ml
+++ b/lib/base/macs2.ml
@@ -1,4 +1,4 @@
-open Base
+
 open Rresult
 
 let parse_field f field x =

--- a/lib/base/macs2.mli
+++ b/lib/base/macs2.mli
@@ -20,7 +20,7 @@ module Xls : sig
     name : string ;
   }
 
-  val parse : Line.t -> (item,  [> `Msg of string]) result
+  val parse : Line.t -> (item,  [> `Msg of string]) Caml.result
 end
 
 module Broad_peaks : sig
@@ -36,5 +36,5 @@ module Broad_peaks : sig
     log10qvalue : float ;
   }
 
-  val parse : Line.t -> (item,  [> `Msg of string]) result
+  val parse : Line.t -> (item,  [> `Msg of string]) Caml.result
 end

--- a/lib/base/macs2.mli
+++ b/lib/base/macs2.mli
@@ -20,7 +20,7 @@ module Xls : sig
     name : string ;
   }
 
-  val parse : Line.t -> (item,  [> `Msg of string]) Caml.result
+  val parse : Line.t -> (item,  [> `Msg of string]) Result.t
 end
 
 module Broad_peaks : sig
@@ -36,5 +36,5 @@ module Broad_peaks : sig
     log10qvalue : float ;
   }
 
-  val parse : Line.t -> (item,  [> `Msg of string]) Caml.result
+  val parse : Line.t -> (item,  [> `Msg of string]) Result.t
 end

--- a/lib/base/table.ml
+++ b/lib/base/table.ml
@@ -1,4 +1,4 @@
-open Base
+
 
 module Field (* field parsing *) = struct
   type 'a result = ('a, string) Result.t

--- a/lib/base/table.mli
+++ b/lib/base/table.mli
@@ -1,5 +1,5 @@
 module Field : sig
-  type 'a result = ('a, string) Caml.result
+  type 'a result = ('a, string) Result.t
   type 'a parser = string -> 'a result
 
   val int : int parser

--- a/lib/base/table.mli
+++ b/lib/base/table.mli
@@ -1,5 +1,5 @@
 module Field : sig
-  type 'a result = ('a, string) Pervasives.result
+  type 'a result = ('a, string) Caml.result
   type 'a parser = string -> 'a result
 
   val int : int parser

--- a/lib/base/ucsc_genome_browser.ml
+++ b/lib/base/ucsc_genome_browser.ml
@@ -89,7 +89,7 @@ let unparse_track_attribute buf = function
 let track_line opts =
   let buf = Buffer.create 1024 in
   bprintf buf "track" ;
-  List.iter (unparse_track_attribute buf) opts ;
+  List.iter ~f:(unparse_track_attribute buf) opts ;
   Buffer.contents buf
 
 type url_param = [
@@ -116,8 +116,8 @@ let encode_url_param = function
   | `textSize n -> sprintf "textSize=%d" n
 
 let encode_url_params xs =
-  List.map encode_url_param xs
-  |> String.concat "&"
+  List.map ~f:encode_url_param xs
+  |> String.concat ~sep:"&"
 
 let custom_track_url ?(params = []) ~db ~position ~data_url () =
   sprintf

--- a/lib/ez/bam.ml
+++ b/lib/ez/bam.ml
@@ -1,4 +1,3 @@
-open Core_kernel
 open CFStream
 
 include Biocaml_unix.Bam

--- a/lib/ez/fasta.ml
+++ b/lib/ez/fasta.ml
@@ -1,4 +1,3 @@
-open Core_kernel
 open CFStream
 
 include Biocaml_unix.Fasta

--- a/lib/ez/fastq.ml
+++ b/lib/ez/fastq.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 open Biocaml_unix.Fastq
 

--- a/lib/ez/jbuild
+++ b/lib/ez/jbuild
@@ -4,5 +4,6 @@
  ((name biocaml_ez)
   (public_name biocaml.ez)
   (libraries (biocaml.unix))
+  (flags (-open Core_kernel))
   (preprocess (pps (ppx_jane)))
   ))

--- a/lib/ez/jbuild
+++ b/lib/ez/jbuild
@@ -4,6 +4,6 @@
  ((name biocaml_ez)
   (public_name biocaml.ez)
   (libraries (biocaml.unix))
-  (flags (-open Core_kernel))
+  (flags (:standard -short-paths -open Core_kernel))
   (preprocess (pps (ppx_jane)))
   ))

--- a/lib/ez/lines.ml
+++ b/lib/ez/lines.ml
@@ -1,5 +1,5 @@
 open CFStream
-open Core_kernel
+
 include Biocaml_unix.Lines
 
 let file_mapper inbed outbed ~f =

--- a/lib/ez/phred_score.ml
+++ b/lib/ez/phred_score.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 include Biocaml_unix.Phred_score
 

--- a/lib/ez/range.ml
+++ b/lib/ez/range.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 include Biocaml_unix.Range
 

--- a/lib/ez/roman_num.ml
+++ b/lib/ez/roman_num.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 include Biocaml_unix.Roman_num
 

--- a/lib/ez/sam.ml
+++ b/lib/ez/sam.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 include Biocaml_unix.Sam

--- a/lib/ez/seq_range.ml
+++ b/lib/ez/seq_range.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 include Biocaml_unix.Seq_range
 

--- a/lib/ez/strand.ml
+++ b/lib/ez/strand.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 include Biocaml_unix.Strand
 

--- a/lib/lwt/future_lwt.ml
+++ b/lib/lwt/future_lwt.ml
@@ -1,5 +1,3 @@
-open Core_kernel
-
 type how = [ `Parallel | `Sequential | `Max_concurrent_jobs of int ]
 
 module Deferred = struct

--- a/lib/lwt/jbuild
+++ b/lib/lwt/jbuild
@@ -4,6 +4,7 @@
  ((name biocaml_lwt)
   (public_name biocaml.lwt)
   (libraries (biocaml.unix lwt.unix))
+  (flags (:standard))
   (preprocess (pps (ppx_jane)))
   (optional)
   ))

--- a/lib/lwt/jbuild
+++ b/lib/lwt/jbuild
@@ -4,7 +4,7 @@
  ((name biocaml_lwt)
   (public_name biocaml.lwt)
   (libraries (biocaml.unix lwt.unix))
-  (flags (:standard))
+  (flags (:standard -short-paths))
   (preprocess (pps (ppx_jane)))
   (optional)
   ))

--- a/lib/lwt/jbuild
+++ b/lib/lwt/jbuild
@@ -4,7 +4,7 @@
  ((name biocaml_lwt)
   (public_name biocaml.lwt)
   (libraries (biocaml.unix lwt.unix))
-  (flags (:standard -short-paths))
+  (flags (:standard -short-paths -open Core_kernel))
   (preprocess (pps (ppx_jane)))
   (optional)
   ))

--- a/lib/test/bam.ml
+++ b/lib/test/bam.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 module Bam = Biocaml_unix.Bam
 module Sam = Biocaml_unix.Sam

--- a/lib/test/bed.ml
+++ b/lib/test/bed.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 module Bed = Biocaml_unix.Bed
 module Tfxm = Biocaml_unix.Tfxm

--- a/lib/test/bgzf.ml
+++ b/lib/test/bgzf.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Bgzf = Biocaml_unix.Bgzf
 open OUnit
 

--- a/lib/test/bin_pred.ml
+++ b/lib/test/bin_pred.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Bin_pred = Biocaml_unix.Bin_pred
 open OUnit
 

--- a/lib/test/biocaml_test_zip.ml
+++ b/lib/test/biocaml_test_zip.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 module Bed = Biocaml_unix.Bed
 module Tfxm = Biocaml_unix.Tfxm

--- a/lib/test/fasta.ml
+++ b/lib/test/fasta.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open OUnit
 open Rresult
 

--- a/lib/test/gff.ml
+++ b/lib/test/gff.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Gff = Biocaml_unix.Gff
 module Tfxm = Biocaml_unix.Tfxm
 open OUnit

--- a/lib/test/interval_tree.ml
+++ b/lib/test/interval_tree.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 open Stream.Infix
 module Interval_tree = Biocaml_unix.Interval_tree

--- a/lib/test/jbuild
+++ b/lib/test/jbuild
@@ -4,5 +4,6 @@
  ((name biocaml_test)
   (libraries (biocaml.unix oUnit))
   (preprocess (pps (ppx_jane)))
+  (flags (:standard -open Core))
   (optional)
   ))

--- a/lib/test/jbuild
+++ b/lib/test/jbuild
@@ -4,6 +4,6 @@
  ((name biocaml_test)
   (libraries (biocaml.unix oUnit))
   (preprocess (pps (ppx_jane)))
-  (flags (:standard -open Core))
+  (flags (:standard -short-paths -open Core))
   (optional)
   ))

--- a/lib/test/line.ml
+++ b/lib/test/line.ml
@@ -1,4 +1,3 @@
-open Base
 open Biocaml_base
 open OUnit
 

--- a/lib/test/lines.ml
+++ b/lib/test/lines.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 open OUnit
 

--- a/lib/test/phred_score.ml
+++ b/lib/test/phred_score.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Phred_score = Biocaml_unix.Phred_score
 open OUnit
 

--- a/lib/test/pwm.ml
+++ b/lib/test/pwm.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Pwm = Biocaml_unix.Pwm
 open OUnit
 open Pwm

--- a/lib/test/rSet.ml
+++ b/lib/test/rSet.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Range = Biocaml_unix.Range
 module RSet = Biocaml_unix.RSet
 open OUnit

--- a/lib/test/roman_num.ml
+++ b/lib/test/roman_num.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Roman_num = Biocaml_unix.Roman_num
 open OUnit
 

--- a/lib/test/sam.ml
+++ b/lib/test/sam.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open OUnit
 open Or_error.Monad_infix
 module Sam = Biocaml_unix.Sam

--- a/lib/test/table.ml
+++ b/lib/test/table.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Table = Biocaml_unix.Table
 module Line = Biocaml_unix.Line
 open OUnit

--- a/lib/test/track.ml
+++ b/lib/test/track.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Gff = Biocaml_unix.Gff
 module Track = Biocaml_unix.Track
 module Tfxm = Biocaml_unix.Tfxm

--- a/lib/test/ucsc_genome_browser.ml
+++ b/lib/test/ucsc_genome_browser.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module UGB = Biocaml_base.Ucsc_genome_browser
 open OUnit
 

--- a/lib/test/utils.ml
+++ b/lib/test/utils.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 let test_data_path = "../etc/test_data"
 

--- a/lib/test/vcf.ml
+++ b/lib/test/vcf.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 module Tfxm = Biocaml_unix.Tfxm
 module Vcf = Biocaml_unix.Vcf

--- a/lib/test/wig.ml
+++ b/lib/test/wig.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 module Tfxm = Biocaml_unix.Tfxm
 module Wig = Biocaml_unix.Wig

--- a/lib/unix/accu.ml
+++ b/lib/unix/accu.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type ('a,'b,'c,'d) t = {

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Result = Biocaml_result
 open CFStream
 open Or_error

--- a/lib/unix/bam.mli
+++ b/lib/unix/bam.mli
@@ -5,7 +5,7 @@
     specification}.
 *)
 
-open Core_kernel
+
 
 (** A BAM file is composed of a header and a list of alignment
     records. The datatypes used in this module are based on those

--- a/lib/unix/bamstats.ml
+++ b/lib/unix/bamstats.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = {
   total : int ;

--- a/lib/unix/bamstats.mli
+++ b/lib/unix/bamstats.mli
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = {
   total : int ;

--- a/lib/unix/bar.ml
+++ b/lib/unix/bar.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type header = (string * string) list

--- a/lib/unix/bed.ml
+++ b/lib/unix/bed.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type item = string * int * int * Table.Row.t

--- a/lib/unix/bed.mli
+++ b/lib/unix/bed.mli
@@ -80,11 +80,11 @@ exception Error of  Error.t
 (** The exception raised by the [*_exn] functions. *)
 
 val in_channel_to_item_stream : ?buffer_size:int -> ?more_columns:parsing_spec ->
-  in_channel -> (item, [> Error.parsing]) result Stream.t
+  In_channel.t -> (item, [> Error.parsing]) result Stream.t
 (** Parse an input-channel into [item] values. *)
 
 val in_channel_to_item_stream_exn: ?buffer_size:int -> ?more_columns:parsing_spec ->
-  in_channel -> item Stream.t
+  In_channel.t -> item Stream.t
 (** Like [in_channel_to_item_stream] but use exceptions for errors
     (raised within [Stream.next]). *)
 

--- a/lib/unix/bin_pred.ml
+++ b/lib/unix/bin_pred.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type confusion_matrix = {
   tp : int ;

--- a/lib/unix/biocaml_result.ml
+++ b/lib/unix/biocaml_result.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 include Result
 

--- a/lib/unix/biocaml_result.mli
+++ b/lib/unix/biocaml_result.mli
@@ -1,5 +1,5 @@
 (** Extension of Core's Result. Internal use only. *)
-open Core_kernel
+
 
 include module type of Result
 

--- a/lib/unix/bpmap.ml
+++ b/lib/unix/bpmap.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type probe = {org_name:string; version:string; chr_name:string; start_pos:int; sequence:Seq.t}

--- a/lib/unix/cel.ml
+++ b/lib/unix/cel.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type idata = {mean:float; stdv:float; npixels:int}

--- a/lib/unix/chr.ml
+++ b/lib/unix/chr.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 module Error = struct
   type t = [

--- a/lib/unix/chr.mli
+++ b/lib/unix/chr.mli
@@ -22,7 +22,7 @@
     because the Roman form is incomplete; e.g. it cannot represent chromosome
     number 10 because there would be an ambiguity with the maternal
     chromosome "chrX". *)
-open Core_kernel
+
 
 module Error : sig
 

--- a/lib/unix/entrez.ml
+++ b/lib/unix/entrez.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 (* ********************************* *)
 (* Preliminary stuff for xml parsing *)

--- a/lib/unix/fasta.ml
+++ b/lib/unix/fasta.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Result = Biocaml_result
 open CFStream
 

--- a/lib/unix/fasta.mli
+++ b/lib/unix/fasta.mli
@@ -85,7 +85,7 @@
     - [alphabet]: Require sequence characters to be at most those in
     given string. None means any character is allowed. Default: None.
 *)
-open Core_kernel
+
 
 (** A header is a list of comment lines. *)
 type header = private string list

--- a/lib/unix/fastq.ml
+++ b/lib/unix/fastq.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type item = {
   name: string;

--- a/lib/unix/fastq.mli
+++ b/lib/unix/fastq.mli
@@ -45,7 +45,7 @@
     span multiple lines. This is discouraged and is not supported by
     this module.
 *)
-open Core_kernel
+
 
 type item = {
   name: string;

--- a/lib/unix/file_mapper.ml
+++ b/lib/unix/file_mapper.ml
@@ -1,5 +1,5 @@
 open CFStream
-open Core_kernel
+
 
 module B = Biocaml_base
 

--- a/lib/unix/future.ml
+++ b/lib/unix/future.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 module type S = sig
 

--- a/lib/unix/future_unix.ml
+++ b/lib/unix/future_unix.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type how = [ `Parallel | `Sequential | `Max_concurrent_jobs of int ]

--- a/lib/unix/future_unix.mli
+++ b/lib/unix/future_unix.mli
@@ -1,5 +1,5 @@
 include Future.S
   with type 'a Deferred.t = 'a
   and type 'a Pipe.Reader.t = 'a Stream.t
-  and type Reader.t = in_channel
-  and type Writer.t = out_channel
+  and type Reader.t = In_channel.t
+  and type Writer.t = Out_channel.t

--- a/lib/unix/genomeMap.ml
+++ b/lib/unix/genomeMap.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 open Stream.Infix
 

--- a/lib/unix/gff.ml
+++ b/lib/unix/gff.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 (*

--- a/lib/unix/gff.mli
+++ b/lib/unix/gff.mli
@@ -98,12 +98,12 @@ exception Error of  Error.t
 (** The exception raised by the [*_exn] functions. *)
 
 val in_channel_to_item_stream : ?buffer_size:int -> ?filename:string ->
-  ?tags:Tags.t -> in_channel ->
+  ?tags:Tags.t -> In_channel.t ->
   (item, [> Error.parsing]) result Stream.t
 (** Parse an input-channel into [item] values. *)
 
 val in_channel_to_item_stream_exn : ?buffer_size:int -> ?tags:Tags.t ->
-  in_channel -> item Stream.t
+  In_channel.t -> item Stream.t
 (** Like [in_channel_to_item_stream] but use exceptions for errors
     (raised within [Stream.next]). *)
 

--- a/lib/unix/histogram.ml
+++ b/lib/unix/histogram.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type 'a t = {
   cmp: 'a -> 'a -> int; (* comparison function of bin limit type *)

--- a/lib/unix/histogram.mli
+++ b/lib/unix/histogram.mli
@@ -7,7 +7,7 @@
     numbered 0. The count of a bin is a floating point number,
     allowing fractional values if necessary.
 *)
-open Core_kernel
+
 
 type 'a t
     (** The type of a histogram whose bin limits are of type ['a]. *)

--- a/lib/unix/interval_tree.ml
+++ b/lib/unix/interval_tree.ml
@@ -3,7 +3,7 @@
  * standard library and the BatSet module (from Batteries) for enum-related
  * functions
  *)
-open Core_kernel
+
 open CFStream
 
 type 'a t = Empty | Node of 'a node

--- a/lib/unix/iset.ml
+++ b/lib/unix/iset.ml
@@ -5,7 +5,7 @@
 (* Copyright 2003 Yamagata Yoriyuki. distributed with LGPL *)
 (* Modified by Edgar Friendly <thelema314@gmail.com> *)
 
-module Int = Core_kernel.Int
+module Int = Int
 open CFStream
 
 module BatAvlTree = struct

--- a/lib/unix/jaspar.ml
+++ b/lib/unix/jaspar.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 let (/) = Filename.concat
 

--- a/lib/unix/jaspar.ml
+++ b/lib/unix/jaspar.ml
@@ -89,8 +89,8 @@ let load_matrix_data fn =
 
 
 module SS = struct
-  include Core_kernel.Tuple.Make(String)(String)
-  include Core_kernel.Tuple.Comparable(String)(String)
+  include Tuple.Make(String)(String)
+  include Tuple.Comparable(String)(String)
 end
 
 module SSM = Map.Make(SS)

--- a/lib/unix/jbuild
+++ b/lib/unix/jbuild
@@ -4,7 +4,7 @@
  ((name biocaml_unix)
   (public_name biocaml.unix)
   (c_names (mzData_stubs pwm_stub))
-  (flags (:standard -unsafe-string))
+  (flags (:standard -unsafe-string -open Core_kernel))
   (libraries (base64 biocaml.base camlzip cfstream core_kernel re.perl xmlm))
   (preprocess (pps (ppx_jane)))
   ))

--- a/lib/unix/jbuild
+++ b/lib/unix/jbuild
@@ -4,7 +4,7 @@
  ((name biocaml_unix)
   (public_name biocaml.unix)
   (c_names (mzData_stubs pwm_stub))
-  (flags (:standard -unsafe-string -open Core_kernel))
+  (flags (:standard -short-paths -unsafe-string -open Core_kernel))
   (libraries (base64 biocaml.base camlzip cfstream core_kernel re.perl xmlm))
   (preprocess (pps (ppx_jane)))
   ))

--- a/lib/unix/lines.ml
+++ b/lib/unix/lines.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type item = Line.t

--- a/lib/unix/lines.mli
+++ b/lib/unix/lines.mli
@@ -23,13 +23,13 @@ include module type of MakeIO(Future_unix)
 val of_char_stream : char Stream.t -> item Stream.t
 (** Parse a stream of characters into a stream of lines. *)
 
-val of_channel : in_channel -> item Stream.t
+val of_channel : In_channel.t -> item Stream.t
 (** Get a stream of lines out of an input-channel. *)
 
 val of_string : string -> item Stream.t
 (** Get a stream of lines out a string *)
 
-val to_channel : item Stream.t -> out_channel -> unit
+val to_channel : item Stream.t -> Out_channel.t -> unit
 (** Write a stream of lines to an output-channel. *)
 
 val with_file :

--- a/lib/unix/math.ml
+++ b/lib/unix/math.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 exception ValueError of string
 

--- a/lib/unix/msg.ml
+++ b/lib/unix/msg.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 let msg ?(pre="MSG") ?pos msg =
   match pos with

--- a/lib/unix/mzData.ml
+++ b/lib/unix/mzData.ml
@@ -17,7 +17,7 @@
 
 (* http://www.umanitoba.ca/afs/plant_science/psgendb/local/install/ncbi_cxx--Jun_15_2010/src/algo/ms/formats/mzdata/mzData.dtd *)
 
-open Core_kernel
+
 open Bigarray
 
 type vec = (float, float64_elt, fortran_layout) Array1.t

--- a/lib/unix/phred_score.ml
+++ b/lib/unix/phred_score.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = int
 [@@deriving sexp]

--- a/lib/unix/phred_score.mli
+++ b/lib/unix/phred_score.mli
@@ -20,7 +20,7 @@
     fastq-illumina is now misleading since Illumina has also switched
     to using an offset of 33.
 *)
-open Core_kernel
+
 
 type t = private int
 [@@deriving sexp]

--- a/lib/unix/pos.ml
+++ b/lib/unix/pos.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = {
   source : string option;

--- a/lib/unix/psl.ml
+++ b/lib/unix/psl.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Result = Biocaml_result
 open CFStream
 

--- a/lib/unix/psl.mli
+++ b/lib/unix/psl.mli
@@ -36,11 +36,11 @@ end
 
 exception Error of Error.t
 
-val in_channel_to_item_stream : ?buffer_size:int -> ?filename:string -> in_channel ->
+val in_channel_to_item_stream : ?buffer_size:int -> ?filename:string -> In_channel.t ->
   (item, [> Error.t]) result Stream.t
 
 val in_channel_to_item_stream_exn:
-  ?buffer_size:int -> ?filename:string -> in_channel -> item Stream.t
+  ?buffer_size:int -> ?filename:string -> In_channel.t -> item Stream.t
 
 module Transform : sig
 

--- a/lib/unix/pwm.ml
+++ b/lib/unix/pwm.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type count_matrix = int array array

--- a/lib/unix/rSet.ml
+++ b/lib/unix/rSet.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = Range.t list (* retained in canonical form *)
 type range = Range.t

--- a/lib/unix/range.ml
+++ b/lib/unix/range.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = {lo:int; hi:int}
 [@@deriving compare, sexp]

--- a/lib/unix/range.mli
+++ b/lib/unix/range.mli
@@ -2,7 +2,7 @@
     contiguous sequence of integers from a lower bound to an upper
     bound. For example, [\[2, 10\]] is the set of integers from 2 through
     10, inclusive of 2 and 10. *)
-open Core_kernel
+
 
 (** Type of a range. *)
 type t = private {lo:int; hi:int}

--- a/lib/unix/roman_num.ml
+++ b/lib/unix/roman_num.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 module Roman = struct
   (* Roman module courtesy of Nathan Mishra Linger, as posted on Caml List. *)

--- a/lib/unix/roman_num.mli
+++ b/lib/unix/roman_num.mli
@@ -1,6 +1,6 @@
 (** Roman numerals. Values greater than or equal to 1 are valid roman
     numerals. *)
-open Core_kernel
+
 
 type t = private int
 

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 module Result = Biocaml_result
 open Result.Monad_infix
 

--- a/lib/unix/sam.mli
+++ b/lib/unix/sam.mli
@@ -1,7 +1,7 @@
 (** SAM files. Documentation here assumes familiarity with the {{:
     http://samtools.github.io/hts-specs/SAMv1.pdf } SAM
     specification}. *)
-open Core_kernel
+
 
 (******************************************************************************)
 (** {2 Types} *)

--- a/lib/unix/sbml.ml
+++ b/lib/unix/sbml.ml
@@ -252,7 +252,7 @@ module MathML = struct
 
   let unpack_symbol_type attrs =
     let (_,sbmlUrl) = List.find_exn ~f:(fun next -> let ((_,tag), _) = next in tag = "definitionURL") attrs in
-    let splitUrl = Core_kernel.String.split ~on:'/' sbmlUrl in
+    let splitUrl = String.split ~on:'/' sbmlUrl in
     List.nth_exn splitUrl (List.length splitUrl - 1)
 
   let parse_bvarlist i =

--- a/lib/unix/sbml.mli
+++ b/lib/unix/sbml.mli
@@ -186,10 +186,10 @@ type sb_model = {
  (*constraints : sb_constraint list;
  compartmentTypes : sb_compartment_type list;
  speciesTypes : sb_species_type list;*)
-}     
+}
 
 val math_to_string : sb_math -> string
   (** Returns a string with sb_math converted into a S-expression  *)
 
-val in_sbml : in_channel -> sb_model
+val in_sbml : In_channel.t -> sb_model
   (** Returns an sb_model read from input stream *)

--- a/lib/unix/seq.ml
+++ b/lib/unix/seq.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = string
 exception Bad of string

--- a/lib/unix/seq_range.ml
+++ b/lib/unix/seq_range.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 module type Identifier = sig
   include Comparable

--- a/lib/unix/seq_range.mli
+++ b/lib/unix/seq_range.mli
@@ -11,7 +11,7 @@
     of operations on {! Range.t}.
 *)
 
-open Core_kernel
+
 
 module type Identifier = sig
   include Comparable

--- a/lib/unix/sgr.ml
+++ b/lib/unix/sgr.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = (string * int * float) list
     (* Stored in ascending order by (string,int) pairs. *)

--- a/lib/unix/sgr.mli
+++ b/lib/unix/sgr.mli
@@ -4,12 +4,12 @@ type t
 
 exception Bad of string
 
-val of_channel : ?chr_map:(string -> string) -> ?increment_bp:int -> in_channel -> t
+val of_channel : ?chr_map:(string -> string) -> ?increment_bp:int -> In_channel.t -> t
 val of_file : ?chr_map:(string -> string) -> ?increment_bp:int -> string -> t
 val of_list : (string * int * float) list -> t
 val of_chr_lists : (string * (int * float) list) list -> t
 
-val to_channel : ?chr_map:(string -> string) -> ?increment_bp:int -> t -> out_channel -> unit
+val to_channel : ?chr_map:(string -> string) -> ?increment_bp:int -> t -> Out_channel.t -> unit
 val to_file : ?chr_map:(string -> string) -> ?increment_bp:int -> t -> string -> unit
   (** Items will be printed in ascending order by [(chr,coord)]. *)
 

--- a/lib/unix/solexa_score.ml
+++ b/lib/unix/solexa_score.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 exception Error of string
 

--- a/lib/unix/strand.ml
+++ b/lib/unix/strand.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = char
 

--- a/lib/unix/strand.mli
+++ b/lib/unix/strand.mli
@@ -2,7 +2,7 @@
     two strands of DNA. This module provides an [of_string] function
     that parses the various conventions into a canonical
     representation, which we define to be '-' or '+'. *)
-open Core_kernel
+
 
 (** Only valid values are '-' or '+'. *)
 type t = private char

--- a/lib/unix/table.ml
+++ b/lib/unix/table.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 module Row = struct
 

--- a/lib/unix/table.mli
+++ b/lib/unix/table.mli
@@ -1,5 +1,5 @@
 (** Generic “tables” (like CSV, TSV, Bed …). *)
-open Core_kernel
+
 
 (** {2 Table Rows/Lines } *)
 

--- a/lib/unix/tfxm.ml
+++ b/lib/unix/tfxm.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type ('input, 'output) t = {

--- a/lib/unix/tfxm.mli
+++ b/lib/unix/tfxm.mli
@@ -97,13 +97,13 @@ val to_stream_fun:
     given a transform [t] that knows how to produce ['output]s from
     strings. The strings are read from the in_channel. *)
 val in_channel_strings_to_stream :
-  ?buffer_size:int -> in_channel -> (string, 'output) t -> 'output Stream.t
+  ?buffer_size:int -> In_channel.t -> (string, 'output) t -> 'output Stream.t
 
 (** [stream_to_out_channel xs t oc] consumes a stream of ['input]s
     using [t] to transform them into strings, which are then written
     on the out_channel [oc]. *)
 val stream_to_out_channel :
-  'input Stream.t -> ('input, string) t -> out_channel ->  unit
+  'input Stream.t -> ('input, string) t -> Out_channel.t ->  unit
 
 (** {2 Compose}
 

--- a/lib/unix/track.ml
+++ b/lib/unix/track.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 type t = [
 | `track of (string * string) list

--- a/lib/unix/track.mli
+++ b/lib/unix/track.mli
@@ -47,7 +47,7 @@
     - [type] - "wiggle_0" is the only value currently supported,
       leaving this attribute unset handles other track types
 *)
-open Core_kernel
+
 
 (** {2 Item Types} *)
 

--- a/lib/unix/vcf.ml
+++ b/lib/unix/vcf.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 
 module Safe = struct
   type error = [ `invalid_int of string

--- a/lib/unix/vcf.mli
+++ b/lib/unix/vcf.mli
@@ -3,7 +3,7 @@
     This module implements VCFv4.1, as defined by 1000 genomes project:
     http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41 *)
 
-open Core_kernel
+
 
 type vcf_id = string
 type vcf_description = string

--- a/lib/unix/wig.ml
+++ b/lib/unix/wig.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 type comment = [

--- a/lib/unix/wig.mli
+++ b/lib/unix/wig.mli
@@ -127,21 +127,21 @@ exception Error of  Error.t
 (** The exceptions raised by the [Wig] module's [*_exn] functions. *)
 
 val in_channel_to_item_stream: ?buffer_size:int -> ?filename:string ->
-  ?tags:Tags.t -> in_channel -> (item, Error.t) result Stream.t
+  ?tags:Tags.t -> In_channel.t -> (item, Error.t) result Stream.t
 (** Get a stream of [item] values out of an input-channel. *)
 
 val in_channel_to_item_stream_exn: ?buffer_size:int -> ?filename:string ->
-  ?tags:Tags.t -> in_channel -> item Stream.t
+  ?tags:Tags.t -> In_channel.t -> item Stream.t
 (** Do like [in_channel_to_item_stream] but each call to [Stream.next]
     may throw an exception. *)
 
 val in_channel_to_bed_graph:  ?buffer_size:int -> ?filename:string ->
-  ?tags:Tags.t -> in_channel ->
+  ?tags:Tags.t -> In_channel.t ->
   (bed_graph_value, Error.t) result Stream.t
 (** Get a stream of [bed_graph_value] values out of a WIG-file input-channel. *)
 
 val in_channel_to_bed_graph_exn: ?buffer_size:int -> ?filename:string ->
-  ?tags:Tags.t -> in_channel -> bed_graph_value Stream.t
+  ?tags:Tags.t -> In_channel.t -> bed_graph_value Stream.t
 (** Do like [in_channel_to_bed_graph] but each call to [Stream.next]
     may throw an exception. *)
 

--- a/lib/unix/zip.ml
+++ b/lib/unix/zip.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+
 open CFStream
 
 module Default = struct

--- a/lib/unix/zip.mli
+++ b/lib/unix/zip.mli
@@ -55,13 +55,13 @@ end
 
 val unzip_in_channel :
   ?format:[ `gzip | `raw ] -> ?zlib_buffer_size:int ->
-  ?buffer_size:int -> in_channel ->
+  ?buffer_size:int -> In_channel.t ->
   (string, [> Error.t]) result Stream.t
 (** Decompress an Input Channel. *)
 
 val zip_in_channel :
   ?format:[ `gzip | `raw ] -> ?zlib_buffer_size:int -> ?level:int ->
-  ?buffer_size:int -> in_channel ->
+  ?buffer_size:int -> In_channel.t ->
   string Stream.t
 (** Compress an Input Channel. *)
 
@@ -70,7 +70,7 @@ exception Error of Error.unzip
 
 val unzip_in_channel_exn :
   ?format:[ `gzip | `raw ] -> ?zlib_buffer_size:int ->
-  ?buffer_size:int -> in_channel ->
+  ?buffer_size:int -> In_channel.t ->
   string Stream.t
 (** Like [unzip_in_channel] but calls to [Stream.next] may raise
     [Error e] exceptions. *)


### PR DESCRIPTION
This PR introduces two cross cutting changes to biocaml.

 * biocaml now builds without error or warnings using the strict by default dune `--dev` flag.
 * open statements common to a library are now listed in the jbuild files via the `-open` compiler flag.
 
The `--dev` compatibility changes are incremental- the code now explicitly uses the `caml` module where ideally it would use a `core` or `async` equivalent, for instance, but its a still a step in the right direction.

Finally, the changes have been tested with real data via the `sam` and `fastq` modules but by no means was rigorous. While I think the commit should not effect behavior or performance, it would be nice to verify this further somehow.


 
