### PR TITLE
Remove Sexplib module prefix

### DIFF
--- a/lib/base/line.mli
+++ b/lib/base/line.mli
@@ -42,5 +42,5 @@ val concat : ?sep:char -> t list -> t
 
 (** {2 S-Expressions } *)
 
-val t_of_sexp: Sexplib.Sexp.t -> t
-val sexp_of_t: t -> Sexplib.Sexp.t
+val t_of_sexp: Sexp.t -> t
+val sexp_of_t: t -> Sexp.t


### PR DESCRIPTION
This PR removes the `Sexplib` module prefix, which was breaking the build since the introduction of the `opam 2` the `uri 2.0.0' module.
