### PR TITLE
Fixing typos

### DIFF
--- a/lib/base/line.mli
+++ b/lib/base/line.mli
@@ -8,7 +8,7 @@ type t = private string
 val empty : t
 
 (** [parse_string s] splits [s] on newline characters, returning
-    the resuling list of lines. If the final line ended with a
+    the resulting list of lines. If the final line ended with a
     newline, the last string of the list is empty. *)
 val parse_string : string -> t list
 

--- a/lib/test/phred_score.ml
+++ b/lib/test/phred_score.ml
@@ -9,7 +9,7 @@ let test_char_conv () =
   assert_bool
     "char conversion failed"
     (List.for_all visible_chars ~f:(fun i ->
-      let x = i - 33 in (* substract default offset *)
+      let x = i - 33 in (* subtract default offset *)
       Phred_score.(
         x
         |> fun x -> ok_exn (of_int x)

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -348,7 +348,7 @@ module Alignment0 = struct
   (* ==== ALIGNMENT ENCODING ==== *)
   (* ============================ *)
 
-  (* Alignement.t -> Alignment0.t conversion *)
+  (* Alignment.t -> Alignment0.t conversion *)
   let find_ref_id header ref_name =
     let open Or_error in
     match Array.findi header.ref_seq ~f:(fun _ rs -> rs.Sam.name = ref_name) with

--- a/lib/unix/bed.mli
+++ b/lib/unix/bed.mli
@@ -1,7 +1,7 @@
 (** BED data files.
 
     A BED file is in the format shown below, where columns
-    must be separted by a tab character.
+    must be separated by a tab character.
 
     {v
     chrA   lo1   hi1

--- a/lib/unix/bgzf.mli
+++ b/lib/unix/bgzf.mli
@@ -15,7 +15,7 @@ val close_in : in_channel -> unit
     call. *)
 
 val dispose_in : in_channel -> unit
-(** Releases the ressources associated to a (BGZF) channel (it can
+(** Releases the resources associated to a (BGZF) channel (it can
     thus not be used after that call), apart from the underlying
     regular channel (which can be used further). *)
 
@@ -82,7 +82,7 @@ val close_out : out_channel -> unit
     after that call. *)
 
 val dispose_out : out_channel -> unit
-(** Releases the ressources associated to a (BGZF) channel (it can
+(** Releases the resources associated to a (BGZF) channel (it can
     thus not be used after that call), apart from the underlying
     regular channel (which can be used further). *)
 

--- a/lib/unix/bpmap.mli
+++ b/lib/unix/bpmap.mli
@@ -10,7 +10,7 @@ type probe = {
 
 type row = {
   pmcoord : int * int; (** x,y-coordinates of perfect match probe. *)
-  mmcoord : int * int; (** x,y-coordinates of mis-match probe *)
+  mmcoord : int * int; (** x,y-coordinates of mismatch probe *)
   probe : probe
 }
     (** Type of information on one data row. *)

--- a/lib/unix/histogram.mli
+++ b/lib/unix/histogram.mli
@@ -18,7 +18,7 @@ val make : ('a -> 'a -> int) -> 'a list -> 'a t option
     list of the boundaries dividing them. The list [\[v0; v1; ...; vn\]]
     of length [n+1] represents the [n] bins [\[v0, v1)], [\[v1, v2)],
     ..., [\[vn-1, vn)], where [cmp] is used as the comparison
-    function. Resturns [None] if [bins] are not monotonically
+    function. Returns [None] if [bins] are not monotonically
     increasing, or if length of [bins] is less than 2. *)
 
 val to_list : 'a t -> (('a * 'a) * float) list

--- a/lib/unix/math.mli
+++ b/lib/unix/math.mli
@@ -106,7 +106,7 @@ val column : 'a array array -> int -> 'a array
 
 val transpose : 'a array array -> 'a array array
 (** [transpose m] transpose the given matrix [m].  If the number of
-    rows [Array.length m] ot the number of columns [Array.length
+    rows [Array.length m] or the number of columns [Array.length
     a.(0)] is 0, return the empty matrix [[| |]].  Behavior undefined
     if [m] is not rectangular. *)
 

--- a/lib/unix/msg.mli
+++ b/lib/unix/msg.mli
@@ -3,12 +3,12 @@
 val err : ?pos:Pos.t -> string -> string
 val warn : ?pos:Pos.t -> string -> string
 val bug : ?pos:Pos.t -> string -> string
-  (** Create a string communicating an error, warning, or bug. First optional arugment is position where problem ocurred. Second argument is a string explaining the problem. *)
+  (** Create a string communicating an error, warning, or bug. First optional argument is position where problem occurred. Second argument is a string explaining the problem. *)
 
 val print_err : ?pos:Pos.t -> string -> unit
 val print_warn : ?pos:Pos.t -> string -> unit
 val print_bug : ?pos:Pos.t -> string -> unit
-  (** Print an error, warning, or bug. First optional arugment is position where problem ocurred. Second argument is a string explaining the problem. *)
+  (** Print an error, warning, or bug. First optional argument is position where problem occurred. Second argument is a string explaining the problem. *)
 
 val max_array_length_error : string
   (** String explaining OCaml's array length limitation on 32-bit machines. *)

--- a/lib/unix/sbml.ml
+++ b/lib/unix/sbml.ml
@@ -169,7 +169,7 @@ type sb_event = {
   event_assignments: sb_event_assignment list;
 }
 
-(*a wrapper type to deal with heterogenous lists*)
+(*a wrapper type to deal with heterogeneous lists*)
 type sb_L = LFunctionDefinition of sb_function_definition | LUnitDefinition of sb_unit_definition |
             LCompartment of sb_compartment | LSpecies of sb_species | LReaction of sb_reaction |
             LParameter of sb_parameter | LInitialAssignment of sb_initial_assignment | LRule of sb_rule |

--- a/lib/unix/wig.mli
+++ b/lib/unix/wig.mli
@@ -169,7 +169,7 @@ module Transform: sig
     (string, (item, [> Error.parsing]) result) Tfxm.t
   (** Create the parsing [Tfxm.t]. The parser is
       "best-effort" and stateless (i.e. a line containing ["1000 42."]
-      will parsed succesfully as a [`variable_step_value (1000, 42.)]
+      will parsed successfully as a [`variable_step_value (1000, 42.)]
       even if no ["variableStep"] was line present before). *)
 
   val item_to_string: ?tags: Tags.t -> unit -> (item, string) Tfxm.t

--- a/src/tmp/biocaml_app_demux.ml
+++ b/src/tmp/biocaml_app_demux.ml
@@ -467,7 +467,7 @@ let more_help original_help : string =
    \  ;; the undetermined library (reads that do not match other cases)\n\
    \  (library The_undetermined undetermined)\n\
     )\n\
-    ;; Ask for gzipped output files (the interger is the compression level)\n\
+    ;; Ask for gzipped output files (the integer is the compression level)\n\
     (gzip-output 3)\n\
 ";
   par buf "*Entries in the specification file:*";
@@ -484,7 +484,7 @@ let more_help original_help : string =
      A matching rule is either 'undetermined' or a boolean expression
      where the leaves are barcode definitions. There are two syntaxes
      for barcodes: the explicit one (like in the previous example), and
-     the abreviated one: ACTGTT:3:2:1 means 'ACTGTT on read 3 at
+     the abbreviated one: ACTGTT:3:2:1 means 'ACTGTT on read 3 at
      position 2 with mismatch 1'.";
     (* explain alternate syntax here *)
     "`gzip-output`: expects a gzip-compression level (in [1, 9]).";


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell