### PR TITLE
Fix lib/async compatibility with Core v0.15

### DIFF
--- a/lib/async/future_async.ml
+++ b/lib/async/future_async.ml
@@ -68,10 +68,10 @@ module Unix = struct
   (* let getpid = Unix.getpid *)
 
   module Stats = struct
-    type _t = Core.Unix.stats = {
+    type _t = Core_unix.stats = {
       st_dev   : int;
       st_ino   : int;
-      st_kind  : Core.Unix.file_kind;
+      st_kind  : Core_unix.file_kind;
       st_perm  : file_perm;
       st_nlink : int;
       st_uid   : int;
@@ -84,7 +84,7 @@ module Unix = struct
     }
   end
 
-  (* let stat x = In_thread.run (fun () -> Core.Unix.stat x) *)
-  (* let lstat x = In_thread.run (fun () -> Core.Unix.lstat x) *)
+  (* let stat x = In_thread.run (fun () -> Core_unix.stat x) *)
+  (* let lstat x = In_thread.run (fun () -> Core_unix.lstat x) *)
 
 end


### PR DESCRIPTION
In 0.15, Core is now the platform-independent part, and Core_unix
includes the Unix-dependent parts.