### PR TITLE
Replace core.caml_unix with core_kernel.caml_unix

### DIFF
--- a/lib/lwt/dune
+++ b/lib/lwt/dune
@@ -1,7 +1,7 @@
 (library
  (name biocaml_lwt)
  (public_name biocaml.lwt)
- (libraries biocaml.unix core.caml_unix lwt.unix)
+ (libraries biocaml.unix core_kernel.caml_unix lwt.unix)
  (flags :standard -short-paths -open Core)
  (preprocess
   (pps ppx_jane))


### PR DESCRIPTION
The core package doesn't have a library named "core.caml_unix" but there is a library in core_kernel which looks like what we want here.