### PR TITLE
Fix deprecated calls s/Data_bigarray_val/Caml_ba_data_val/g

### DIFF
--- a/lib/unix/mzData_stubs.c
+++ b/lib/unix/mzData_stubs.c
@@ -122,7 +122,7 @@ static const unsigned char of_base64[] = {
   24, /*   Y  */
   25, /*   Z  */
   0,  /*   [  */
-  0,  /* '\'  */ 
+  0,  /* '\'  */
   0,  /*   ]  */
   0,  /*   ^  */
   0,  /*   _  */
@@ -171,17 +171,17 @@ static size_t pack_offset;
    larger than 0x7fffff. */
 
 CAMLexport
-value biocaml_base64_init(value vunit) 
+value biocaml_base64_init(value vunit)
 {
   /* no OCaml alloc */
   int i, j, k, index;
   char *c;
-  
+
   i = 1;
   is_little_endian = ((char *)&i)[0];
   if (is_little_endian) pack_offset = 0;
   else pack_offset = sizeof(int) - 3;
-  
+
   /* Fill the lookup tables */
   for (i='+'; i<='z'; i++) {
     for (j='+'; j<='z'; j++) {
@@ -241,7 +241,7 @@ value biocaml_base64_init(value vunit)
   unsigned int index;                                                   \
   unsigned char *b, buffer[lenbuf]; /* partially decoded string */      \
   ty *data; /* to cast the decoded bytes */                             \
-  double *vec = (double *) Data_bigarray_val(vvec);                     \
+  double *vec = (double *) Caml_ba_data_val(vvec);                     \
                                                                         \
   if (is_little_endian) {                                               \
     DECODE_BODY(ty, lenbuf, INDEX_LITTLE_ENDIAN, to_host_little_endian); \


### PR DESCRIPTION
These functions became deprecated by OCaml 4.14. Replacing them as instructed.

```shell
mzData_stubs.c: In function ‘biocaml_base64_little32’:
mzData_stubs.c:269:13: warning: "Data_bigarray_val" is deprecated: use "Caml_ba_data_val" instead
  269 |   DECODE(float, 12, TO_HOST_IDENTITY, swap_bytes32);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mzData_stubs.c: In function ‘biocaml_base64_big32’:
mzData_stubs.c:277:13: warning: "Data_bigarray_val" is deprecated: use "Caml_ba_data_val" instead
  277 |   DECODE(float, 12, swap_bytes32, TO_HOST_IDENTITY);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mzData_stubs.c: In function ‘biocaml_base64_little64’:
mzData_stubs.c:295:13: warning: "Data_bigarray_val" is deprecated: use "Caml_ba_data_val" instead
  295 |   DECODE(double, 24, TO_HOST_IDENTITY, swap_bytes64);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mzData_stubs.c: In function ‘biocaml_base64_big64’:
mzData_stubs.c:303:13: warning: "Data_bigarray_val" is deprecated: use "Caml_ba_data_val" instead
  303 |   DECODE(double, 24, swap_bytes64, TO_HOST_IDENTITY);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203845762456622