### PR TITLE
Modernize Sam module

### DIFF
--- a/lib/base/dune
+++ b/lib/base/dune
@@ -1,7 +1,7 @@
 (library
  (name biocaml)
  (public_name biocaml)
- (libraries base re uri)
+ (libraries base expect_test_helpers_core.expect_test_helpers_base re uri)
  (inline_tests)
  (flags :standard -short-paths -open Base -open Base.Printf)
  (preprocess

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -9,10 +9,6 @@ let ( >>?~ ) (x : 'a option Or_error.t) (f : 'a -> 'b Or_error.t) : 'b option Or
   | Some x -> f x >>| Option.some
 ;;
 
-(******************************************************************************)
-(* Header Types                                                               *)
-(******************************************************************************)
-
 module Header = struct
   module Header_item_tag = struct
     type t =
@@ -684,9 +680,6 @@ module Header = struct
   ;;
 end
 
-(******************************************************************************)
-(* Alignment Types                                                            *)
-(******************************************************************************)
 module Flags = struct
   type t = int [@@deriving sexp]
 

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -213,7 +213,7 @@ module Header = struct
 
   let print_header_version x = Tag_value.print_tag_value' "VN" x
 
-  module Header_line = struct
+  module HD = struct
     type t =
       { version : string
       ; sort_order : Sort_order.t option
@@ -251,7 +251,7 @@ module Header = struct
     ;;
   end
 
-  module Ref_seq = struct
+  module SQ = struct
     type t =
       { name : string
       ; length : int
@@ -359,7 +359,7 @@ module Header = struct
     ;;
   end
 
-  module Read_group = struct
+  module RG = struct
     type t =
       { id : string
       ; seq_center : string option
@@ -518,7 +518,7 @@ module Header = struct
     ;;
   end
 
-  module Program = struct
+  module PG = struct
     type t =
       { id : string
       ; name : string option
@@ -565,10 +565,10 @@ module Header = struct
 
   module Header_item = struct
     type t =
-      [ `HD of Header_line.t
-      | `SQ of Ref_seq.t
-      | `RG of Read_group.t
-      | `PG of Program.t
+      [ `HD of HD.t
+      | `SQ of SQ.t
+      | `RG of RG.t
+      | `PG of PG.t
       | `CO of string
       | `Other of string * Tag_value.t list
       ]
@@ -577,10 +577,10 @@ module Header = struct
     let parse line =
       let parse_data tag tvl =
         match tag with
-        | `HD -> Header_line.parse tvl >>| fun x -> `HD x
-        | `SQ -> Ref_seq.parse tvl >>| fun x -> `SQ x
-        | `RG -> Read_group.parse tvl >>| fun x -> `RG x
-        | `PG -> Program.parse tvl >>| fun x -> `PG x
+        | `HD -> HD.parse tvl >>| fun x -> `HD x
+        | `SQ -> SQ.parse tvl >>| fun x -> `SQ x
+        | `RG -> RG.parse tvl >>| fun x -> `RG x
+        | `PG -> PG.parse tvl >>| fun x -> `PG x
         | `Other tag -> Ok (`Other (tag, tvl))
         | `CO -> assert false
       in
@@ -611,9 +611,9 @@ module Header = struct
     { version : string option
     ; sort_order : Sort_order.t option
     ; group_order : Group_order.t option
-    ; ref_seqs : Ref_seq.t list
-    ; read_groups : Read_group.t list
-    ; programs : Program.t list
+    ; ref_seqs : SQ.t list
+    ; read_groups : RG.t list
+    ; programs : PG.t list
     ; comments : string list
     ; others : (string * Tag_value.t list) list
     }
@@ -655,7 +655,7 @@ module Header = struct
               (sort_order, version)
               [%sexp_of: Sort_order.t option * string option])
        else None)
-    ; List.map ref_seqs ~f:(fun (x : Ref_seq.t) -> x.name)
+    ; List.map ref_seqs ~f:(fun (x : SQ.t) -> x.name)
       |> List.find_a_dup ~compare:String.compare
       |> Option.map ~f:(fun name ->
         Error.create "duplicate ref seq name" name sexp_of_string)

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -1412,7 +1412,6 @@ module State = struct
 end
 
 let of_lines lines =
-  let on_alignment data _header alignment = alignment :: data in
   let rec loop state lines =
     match lines with
     | [] -> Ok state
@@ -1421,7 +1420,9 @@ let of_lines lines =
       | Error _ as e -> e
       | Ok state -> loop state lines)
   in
-  match loop (State.init ~on_alignment ~data:[]) lines with
+  let on_alignment data _header alignment = alignment :: data in
+  let init = State.init ~on_alignment ~data:[] in
+  match loop init lines with
   | Error _ as e -> e
   | Ok state -> (
     let alignments = List.rev (State.data state) in
@@ -1435,9 +1436,8 @@ let of_lines lines =
    [of_lines] above. *)
 let of_lines_exn lines =
   let on_alignment data _header alignment = alignment :: data in
-  let state =
-    List.fold lines ~init:(State.init ~on_alignment ~data:[]) ~f:State.reduce_exn
-  in
+  let init = State.init ~on_alignment ~data:[] in
+  let state = List.fold lines ~init ~f:State.reduce_exn in
   let header = State.header_exn state in
   let alignments = List.rev (State.data state) in
   header, alignments

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -1125,7 +1125,7 @@ module Alignment = struct
     ; flag : Flag.t
     ; rname : Rname.t option
     ; pos : Pos.t option
-    ; mapq : int option
+    ; mapq : Mapq.t option
     ; cigar : Cigar.t
     ; rnext : Rnext.t option
     ; pnext : Pnext.t option

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -1465,186 +1465,329 @@ let of_string s = s |> String.split_lines |> of_lines
 let of_string_exn s = s |> String.split_lines |> of_lines_exn
 
 module Test = struct
-  (* module Sam = Biocaml_unix.Sam_deprecated *)
-  (* module Tfxm = Biocaml_unix.Tfxm *)
+  open Expect_test_helpers_base
 
-  (* let test_parser_deprecated () = *)
-  (*   let transfo = Sam.Transform.string_to_raw () in *)
-  (*   let test_line l f = *)
-  (*     Tfxm.feed transfo (l ^ "\n"); *)
-  (*     assert_bool l (f (Tfxm.next transfo)) *)
-  (*   in *)
-  (*   let test_output l o = test_line l (fun oo -> `output (Ok o) = oo) in *)
+  let%expect_test "Header.Item.of_string" =
+    let data =
+      [ "@CO\tsome comment"
+      ; "@HD\tVN:1.3\tSO:coordinate"
+      ; "@SQ\tSN:chr0\tLN:42"
+      ; "@SQ\tSN:chr1\tLN:42\tM5:abd34f90"
+      ; "@HD\tT"
+      ]
+    in
+    let test x =
+      let result = Header.Item.of_string x in
+      print_string
+        (sprintf
+           "IN: \"%s\"\nSEXP:\n%s\n"
+           x
+           ([%sexp_of: Header.Item.t Or_error.t] result |> sexp_to_string))
+    in
+    List.iter data ~f:test;
+    [%expect
+      {|
+      IN: "@CO	some comment"
+      SEXP:
+      (Ok (CO "some comment"))
 
-  (*   test_output "@CO\tsome comment" (`comment "some comment"); *)
-  (*   test_output "@HD\tVN:1.3\tSO:coordinate" *)
-  (*     (`header ("HD", [ "VN", "1.3"; "SO", "coordinate"])); *)
-  (*   test_output "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*" *)
-  (*     (`alignment *)
-  (*         {Sam.qname = "r001"; flag = 83; rname = "ref"; pos = 37; mapq = 30; *)
-  (*          cigar = "9M"; rnext = "="; pnext = 7; tlen = -39; seq = "CAGCGCCAT"; *)
-  (*          qual = "*"; optional = []}); *)
-  (*   test_output "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0" *)
-  (*     (`alignment *)
-  (*         {Sam.qname = "r001"; flag = 83; rname = "ref"; pos = 37; mapq = 30; *)
-  (*          cigar = "9M"; rnext = "="; pnext = 7; tlen = -39; seq = "CAGCGCCAT"; *)
-  (*          qual = "*"; optional = [("NM", 'i', "0")]}); *)
-  (*   test_output "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0\tKJ:A:a" *)
-  (*     (`alignment *)
-  (*         {Sam.qname = "r001"; flag = 83; rname = "ref"; pos = 37; mapq = 30; *)
-  (*          cigar = "9M"; rnext = "="; pnext = 7; tlen = -39; seq = "CAGCGCCAT"; *)
-  (*          qual = "*"; optional = [("NM", 'i', "0"); ("KJ", 'A', "a")]}); *)
-  (*   test_line "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0\tKJ:A" *)
-  (*     (function *)
-  (*     | `output (Error (`wrong_optional_field (_, _))) -> true *)
-  (*     | _ -> false); *)
-  (*   test_line "r001\t83\tref\t37\t30\t9M\t=\t7h\t-39\tCAGCGCCAT\t*\tNM:i:0\tKJ:A:a" *)
-  (*     (function *)
-  (*     | `output (Error (`not_an_int (_, "pnext", "7h")))  -> true *)
-  (*     | _ -> false); *)
-  (*   test_line  "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT" *)
-  (*     (function *)
-  (*     | `output (Error (`wrong_alignment (_, _))) -> true *)
-  (*     | _ -> false); *)
-  (*   test_line "@HD\tT" *)
-  (*     (function *)
-  (*     | `output (Error (`invalid_tag_value_list (_, ["T"]))) -> true *)
-  (*     | _ -> false); *)
-  (*   () *)
+      IN: "@HD	VN:1.3	SO:coordinate"
+      SEXP:
+      (Ok (HD ((version 1.3) (sort_order (Coordinate)) (group_order ()))))
 
-  (* let test_item_parser_deprecated () = *)
-  (*   let c = ref 0 in *)
-  (*   let check t v f = *)
-  (*     let p = Sam.Transform.raw_to_string () in *)
-  (*     incr c; *)
-  (*     Tfxm.feed t v; *)
-  (*     let res = f (Tfxm.next t) in *)
-  (*     if not res then *)
-  (*       eprintf "Error on %s\n" *)
-  (*         Tfxm.( *)
-  (*           match feed p v; next p with `output o -> o | _ -> failwith "printer!" *)
-  (*         ); *)
-  (*     assert_bool (sprintf "test_item_parser.check %d" !c) res *)
-  (*   in *)
-  (*   let check_output t v o = check t v ((=) (`output (Ok o))) in *)
+      IN: "@SQ	SN:chr0	LN:42"
+      SEXP:
+      (Ok (
+        SQ (
+          (name   chr0)
+          (length 42)
+          (assembly ())
+          (md5      ())
+          (species  ())
+          (uri      ()))))
 
-  (*   let t = Sam.Transform.raw_to_item () in *)
-  (*   check_output t (`comment "comment") (`comment "comment"); *)
-  (*   check t (`header ("HD", ["VN", "42.1"])) (function *)
-  (*   | `output (Error (`header_line_not_first 2)) -> true *)
-  (*   | _ -> false); *)
+      IN: "@SQ	SN:chr1	LN:42	M5:abd34f90"
+      SEXP:
+      (Ok (
+        SQ (
+          (name   chr1)
+          (length 42)
+          (assembly ())
+          (md5 (abd34f90))
+          (species ())
+          (uri     ()))))
 
-  (*   let t = Sam.Transform.raw_to_item () in *)
-  (*   check_output t (`header ("HD", ["VN", "42.1"])) *)
-  (*     (`header_line ("42.1", `unknown, [])); *)
-  (*   check t (`header ("SQ", [])) (function *)
-  (*   | `output (Error (`missing_ref_sequence_name [])) -> true *)
-  (*   | _ -> false); *)
-  (*   check t (`header ("SQ", ["SN", "chr0"])) (function *)
-  (*   | `output (Error (`missing_ref_sequence_length [("SN", "chr0")])) -> true *)
-  (*   | _ -> false); *)
-  (*   check t (`header ("SQ", ["SN", "chr0"; "LN", "not an int"])) (function *)
-  (*   | `output (Error (`wrong_ref_sequence_length _))  -> true *)
-  (*   | _ -> false); *)
+      IN: "@HD	T"
+      SEXP:
+      (Error ("tag-value not colon separated" T))
+      |}]
+  ;;
 
-  (*   let t = Sam.Transform.raw_to_item () in *)
-  (*   check_output t (`header ("HD", ["VN", "42.1"; *)
-  (*                                   "SO", "coordinate"; "HP", "some other"])) *)
-  (*     (`header_line ("42.1", `coordinate, [("HP", "some other")])); *)
-  (*   check t (`header ("SQ", ["SN", "chr0"; "LN", "42"])) ((=) `not_ready); *)
-  (*   check t (`header ("SQ", ["SN", "chr1"; "LN", "42"; "M5", "abd34f90"])) *)
-  (*     ((=) `not_ready); *)
-  (*   (\* the ref-info is being buffered, the first alignment will output it *\) *)
-  (*   check_output t (`alignment *)
-  (*             {Sam.qname = "r001"; flag = 83; rname = "ref"; pos = 37; mapq = 30; *)
-  (*              cigar = "9M"; rnext = "="; pnext = 7; tlen = -39; seq = "CAGCGCCAT"; *)
-  (*              qual = "*"; optional = [("NM", 'i', "0")]}) *)
-  (*     (`reference_sequence_dictionary *)
-  (*         [| *)
-  (*           {Sam.ref_name = "chr0"; ref_length = 42; ref_assembly_identifier = None; *)
-  (*            ref_checksum = None; ref_species = None; ref_uri = None; *)
-  (*            ref_unknown = []}; *)
-  (*           {Sam.ref_name = "chr1"; ref_length = 42; ref_assembly_identifier = None; *)
-  (*            ref_checksum = Some "abd34f90"; ref_species = None; ref_uri = None; *)
-  (*            ref_unknown = []}; *)
-  (*         |]); *)
-  (*   (\* This one get the previous alignment: *\) *)
-  (*   check_output t *)
-  (*     (`alignment *)
-  (*         {Sam.qname = "chr0"; flag = 83; rname = "chr0"; pos = 37; mapq = 30; *)
-  (*          cigar = "9M"; rnext = "*"; pnext = 7; tlen = -39; seq = "CAGCGCCAT"; *)
-  (*          qual = "*"; optional = [("NM", 'i', "0")]}) *)
-  (*     (`alignment *)
-  (*         {Sam.query_template_name = "r001"; flag = Sam.Flag.of_int 83; *)
-  (*          reference_sequence = `name "ref"; position = Some 37; *)
-  (*          mapping_quality = Some 30; cigar_operations = [|`M 9|]; *)
-  (*          next_reference_sequence = `qname; next_position = Some 7; *)
-  (*          template_length = Some (-39); sequence = `string "CAGCGCCAT"; *)
-  (*          quality = [| |]; optional_content = [ "NM", 'i', `int 0] }); *)
-  (*   Tfxm.stop t; *)
-  (*   (\* We still have one to get: *\) *)
-  (*   assert_bool "last alignment" (Tfxm.next t = *)
-  (*       `output (Ok *)
-  (*                  (`alignment *)
-  (*                      {Sam.query_template_name = "chr0"; flag = Sam.Flag.of_int 83; *)
-  (*                       reference_sequence = *)
-  (*                          `reference_sequence *)
-  (*                            {Sam.ref_name = "chr0"; ref_length = 42; *)
-  (*                             ref_assembly_identifier = None; *)
-  (*                             ref_checksum = None; ref_species = None; ref_uri = None; *)
-  (*                             ref_unknown = []}; *)
-  (*                       position = Some 37; mapping_quality = Some 30; *)
-  (*                       cigar_operations = [|`M 9|]; next_reference_sequence = `none; *)
-  (*                       next_position = Some 7; template_length = Some (-39); *)
-  (*                       sequence = `string "CAGCGCCAT"; quality = [| |]; *)
-  (*                       optional_content = [ "NM", 'i', `int 0]}))); *)
-  (*   assert_bool "EOS" (Tfxm.next t = `end_of_stream); *)
+  let%expect_test "Alignment.of_string" =
+    let data =
+      [ "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*"
+      ; "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0"
+      ; "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0\tKJ:A:a"
+      ; "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0\tKJ:A"
+      ; "r001\t83\tref\t37\t30\t9M\t=\t7h\t-39\tCAGCGCCAT\t*\tNM:i:0\tKJ:A:a"
+      ; "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT"
+      ; "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t!''*((((("
+      ]
+    in
+    let test x =
+      let result = Alignment.of_string x in
+      print_string
+        (sprintf
+           "IN: \"%s\"\nSEXP:\n%s\n"
+           x
+           ([%sexp_of: Alignment.t Or_error.t] result |> sexp_to_string))
+    in
+    List.iter data ~f:test;
+    [%expect
+      {|
+      IN: "r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT	*"
+      SEXP:
+      (Ok (
+        (qname (r001))
+        (flag 83)
+        (rname (ref))
+        (pos   (37))
+        (mapq  (30))
+        (cigar ((Alignment_match 9)))
+        (rnext (Equal_to_RNAME))
+        (pnext (7))
+        (tlen  (-39))
+        (seq   (CAGCGCCAT))
+        (qual            ())
+        (optional_fields ())))
 
-  (*
-     check (`header ("HD", ["VN", "42.1"; "SO", "coordinate"]));
-  check (`header ("HD", ["VN", "42.1"; "SO", "wut?"]));
-  check (`header ("HD", ["VN", "42.1"; "SO", "coordinate"; "HP", "some other"]));
-  check (`header ("HD", []));
-  check (`header ("SQ", []));
-  check (`header ("SQ", ["SN", "chr0"]));
-  check (`header ("SQ", ["SN", "chr0"; "LN", "not an int"]));
-  check (`header ("SQ", ["SN", "chr0"; "LN", "42"]));
-  check (`header ("SQ", ["SN", "chr1"; "LN", "42"; "M5", "abd34f90"]));
-  check (`header ("RR", ["SN", "chr1"; "LN", "42"; "M5", "abd34f90"]));
-  check (`alignment
-            {qname = "r001"; flag = 83; rname = "ref"; pos = 37; mapq = 30;
-             cigar = "9M"; rnext = "="; pnext = 7; tlen = -39; seq = "CAGCGCCAT";
-             qual = "*"; optional = [("NM", 'i', "0")]});
+      IN: "r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT	*	NM:i:0"
+      SEXP:
+      (Ok (
+        (qname (r001))
+        (flag 83)
+        (rname (ref))
+        (pos   (37))
+        (mapq  (30))
+        (cigar ((Alignment_match 9)))
+        (rnext (Equal_to_RNAME))
+        (pnext (7))
+        (tlen  (-39))
+        (seq   (CAGCGCCAT))
+        (qual ())
+        (optional_fields (((tag NM) (value (i 0)))))))
 
-  check (`alignment
-            {qname = "chr0"; flag = 83; rname = "chr0"; pos = 37; mapq = 30;
-             cigar = "9M"; rnext = "*"; pnext = 7; tlen = -39; seq = "CAGCGCCAT";
-             qual = "*"; optional = [("NM", 'i', "0")]});
-  *)
+      IN: "r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT	*	NM:i:0	KJ:A:a"
+      SEXP:
+      (Ok (
+        (qname (r001))
+        (flag 83)
+        (rname (ref))
+        (pos   (37))
+        (mapq  (30))
+        (cigar ((Alignment_match 9)))
+        (rnext (Equal_to_RNAME))
+        (pnext (7))
+        (tlen  (-39))
+        (seq   (CAGCGCCAT))
+        (qual ())
+        (optional_fields (
+          ((tag NM) (value (i 0)))
+          ((tag KJ) (value (A a)))))))
 
-  (* let test_printer_deprecated () = *)
-  (*   let transfo = Sam.Transform.raw_to_string () in *)
-  (*   let test_line i l = *)
-  (*     Tfxm.feed transfo i; *)
-  (*     assert_bool l (Tfxm.next transfo = `output (l ^ "\n")) *)
-  (*   in *)
+      IN: "r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT	*	NM:i:0	KJ:A"
+      SEXP:
+      (Error ("missing TYPE in optional field" A))
 
-  (*   test_line *)
-  (*     (`alignment *)
-  (*         {Sam.qname = "r001"; flag = 83; rname = "ref"; pos = 37; mapq = 30; *)
-  (*          cigar = "9M"; rnext = "="; pnext = 7; tlen = -39; seq = "CAGCGCCAT"; *)
-  (*          qual = "*"; optional = [("NM", 'i', "0")]}) *)
-  (*     "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0"; *)
+      IN: "r001	83	ref	37	30	9M	=	7h	-39	CAGCGCCAT	*	NM:i:0	KJ:A:a"
+      SEXP:
+      (Error ("PNEXT not an int" 7h))
 
-  (*   test_line (`comment "some comment") "@CO\tsome comment" ; *)
-  (*   test_line (`header ("HD", [ "VN", "1.3"; "SO", "coordinate"])) *)
-  (*     "@HD\tVN:1.3\tSO:coordinate"; *)
-  (*   () *)
+      IN: "r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT"
+      SEXP:
+      (Error "alignment line contains < 12 fields")
 
-  (* let tests = "SAM" >::: [ *)
-  (*     "Parse SAM" >:: test_parser ; *)
-  (*     "Parse SAM raw" >:: test_parser_deprecated; *)
-  (*     "Print SAM" >:: test_printer_deprecated; *)
-  (*     "Parse SAM item" >:: test_item_parser_deprecated; *)
-  (*   ] *)
+      IN: "r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT	!''*((((("
+      SEXP:
+      (Ok (
+        (qname (r001))
+        (flag 83)
+        (rname (ref))
+        (pos   (37))
+        (mapq  (30))
+        (cigar ((Alignment_match 9)))
+        (rnext (Equal_to_RNAME))
+        (pnext (7))
+        (tlen  (-39))
+        (seq   (CAGCGCCAT))
+        (qual (0 6 6 9 7 7 7 7 7))
+        (optional_fields ())))
+      |}]
+  ;;
+
+  let%expect_test "Cigar.of_string" =
+    let data = [ "9M"; "8M2I4M1D3M" ] in
+    let test x =
+      let result = Cigar.of_string x in
+      print_string
+        (sprintf
+           "IN: \"%s\"\nSEXP:\n%s\n"
+           x
+           ([%sexp_of: Cigar.t Or_error.t] result |> sexp_to_string))
+    in
+    List.iter data ~f:test;
+    [%expect
+      {|
+      IN: "9M"
+      SEXP:
+      (Ok ((Alignment_match 9)))
+
+      IN: "8M2I4M1D3M"
+      SEXP:
+      (Ok (
+        (Alignment_match 8)
+        (Insertion       2)
+        (Alignment_match 4)
+        (Deletion        1)
+        (Alignment_match 3)))
+      |}]
+  ;;
+
+  let%expect_test "Flag.of_string" =
+    let data = [ "83" ] in
+    let test x =
+      let result = Flag.of_string x in
+      print_string
+        (sprintf
+           "IN: \"%s\"\nSEXP: %s\n"
+           x
+           ([%sexp_of: Flag.t Or_error.t] result |> sexp_to_string))
+    in
+    List.iter data ~f:test;
+    [%expect
+      {|
+      IN: "83"
+      SEXP: (Ok 83)
+      |}]
+  ;;
+
+  let%expect_test "Optional_field.of_string" =
+    let data = [ "NM:i:0"; "KJ:A:a"; "RG:Z:sample1"; "AS:f:123.45" ] in
+    let test x =
+      let result = Optional_field.of_string x in
+      print_string
+        (sprintf
+           "IN: \"%s\"\nSEXP: %s\n"
+           x
+           ([%sexp_of: Optional_field.t Or_error.t] result |> sexp_to_string))
+    in
+    List.iter data ~f:test;
+    [%expect
+      {|
+      IN: "NM:i:0"
+      SEXP: (Ok ((tag NM) (value (i 0))))
+
+      IN: "KJ:A:a"
+      SEXP: (Ok ((tag KJ) (value (A a))))
+
+      IN: "RG:Z:sample1"
+      SEXP: (Ok ((tag RG) (value (Z sample1))))
+
+      IN: "AS:f:123.45"
+      SEXP: (Ok ((tag AS) (value (f 123.45))))
+      |}]
+  ;;
+
+  let%expect_test "of_lines" =
+    let data =
+      [ [ "@HD\tVN:1.3\tSO:coordinate"
+        ; "@SQ\tSN:chr1\tLN:249250621"
+        ; "@CO\tThis is a comment"
+        ; "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0"
+        ; "r002\t0\tchr1\t100\t30\t10M\t*\t0\t0\tACGTACGTAC\t!''*(((((\tRG:Z:sample1"
+        ]
+      ; [ "@HD\tVN:1.3\tSO:coordinate"
+        ; "@SQ\tSN:chr1\tLN:249250621"
+        ; "@CO\tThis is a comment"
+        ; "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*\tNM:i:0"
+        ; "r002\t0\tchr1\t100\t30\t10M\t*\t0\t0\tACGTACGTAC\t*\tRG:Z:sample1"
+        ]
+      ; [ "@SQ\tSN:chr1\tLN:249250621"
+        ; "@HD\tVN:1.3\tSO:coordinate"
+        ; "r002\t0\tchr1\t100\t30\t10M\t*\t0\t0\tACGTACGTAC\t*\tRG:Z:sample1"
+        ]
+      ]
+    in
+    let test lines =
+      let result = of_lines lines in
+      print_string "IN:\n";
+      List.iter lines ~f:(fun x -> print_string (sprintf "%s\n" x));
+      print_string
+        (sprintf
+           "SEXP:\n%s\n"
+           ([%sexp_of: (Header.t * Alignment.t list) Or_error.t] result |> sexp_to_string))
+    in
+    List.iter data ~f:test;
+    [%expect
+      {|
+      IN:
+      @HD	VN:1.3	SO:coordinate
+      @SQ	SN:chr1	LN:249250621
+      @CO	This is a comment
+      r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT	*	NM:i:0
+      r002	0	chr1	100	30	10M	*	0	0	ACGTACGTAC	!''*(((((	RG:Z:sample1
+      SEXP:
+      (Error ("SEQ and QUAL lengths differ" (10 9)))
+
+      IN:
+      @HD	VN:1.3	SO:coordinate
+      @SQ	SN:chr1	LN:249250621
+      @CO	This is a comment
+      r001	83	ref	37	30	9M	=	7	-39	CAGCGCCAT	*	NM:i:0
+      r002	0	chr1	100	30	10M	*	0	0	ACGTACGTAC	*	RG:Z:sample1
+      SEXP:
+      (Ok (
+        ((HD ((version 1.3) (sort_order (Coordinate)) (group_order ())))
+         (SQ (
+           (name   chr1)
+           (length 249250621)
+           (assembly ())
+           (md5      ())
+           (species  ())
+           (uri      ())))
+         (CO "This is a comment"))
+        (((qname (r001))
+          (flag 83)
+          (rname (ref))
+          (pos   (37))
+          (mapq  (30))
+          (cigar ((Alignment_match 9)))
+          (rnext (Equal_to_RNAME))
+          (pnext (7))
+          (tlen  (-39))
+          (seq   (CAGCGCCAT))
+          (qual ())
+          (optional_fields (((tag NM) (value (i 0))))))
+         ((qname (r002))
+          (flag 0)
+          (rname (chr1))
+          (pos   (100))
+          (mapq  (30))
+          (cigar ((Alignment_match 10)))
+          (rnext ())
+          (pnext ())
+          (tlen  ())
+          (seq (ACGTACGTAC))
+          (qual ())
+          (optional_fields (((tag RG) (value (Z sample1)))))))))
+
+      FIXME: The error message is incorrect.
+      IN:
+      @SQ	SN:chr1	LN:249250621
+      @HD	VN:1.3	SO:coordinate
+      r002	0	chr1	100	30	10M	*	0	0	ACGTACGTAC	*	RG:Z:sample1
+      SEXP:
+      (Error "multiple @HD lines not allowed")
+      |}]
+  ;;
 end

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -724,7 +724,7 @@ module Qname = struct
   ;;
 end
 
-module Flags = struct
+module Flag = struct
   type t = int [@@deriving sexp]
 
   let of_int x =
@@ -1121,7 +1121,7 @@ end
 module Alignment = struct
   type t =
     { qname : Qname.t option
-    ; flags : Flags.t
+    ; flag : Flag.t
     ; rname : Rname.t option
     ; pos : Pos.t option
     ; mapq : int option
@@ -1138,7 +1138,7 @@ module Alignment = struct
   let make
         ?ref_seqs
         ?qname
-        ~flags
+        ~flag
         ?rname
         ?pos
         ?mapq
@@ -1185,7 +1185,7 @@ module Alignment = struct
     | [] ->
       Ok
         { qname
-        ; flags
+        ; flag
         ; rname
         ; pos
         ; mapq
@@ -1203,7 +1203,7 @@ module Alignment = struct
   let parse ?ref_seqs line =
     match String.split ~on:'\t' (line : Line.t :> string) with
     | qname
-      :: flags
+      :: flag
       :: rname
       :: pos
       :: mapq
@@ -1216,8 +1216,8 @@ module Alignment = struct
       :: optional_fields ->
       Qname.parse qname
       >>= fun qname ->
-      Flags.parse flags
-      >>= fun flags ->
+      Flag.parse flag
+      >>= fun flag ->
       Rname.parse rname
       >>= fun rname ->
       Pos.parse pos
@@ -1241,7 +1241,7 @@ module Alignment = struct
       make
         ?ref_seqs
         ?qname
-        ~flags
+        ~flag
         ?rname
         ?pos
         ?mapq
@@ -1260,7 +1260,7 @@ module Alignment = struct
     sprintf
       "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
       (Qname.print a.qname)
-      (Flags.print a.flags)
+      (Flag.print a.flag)
       (Rname.print a.rname)
       (Pos.print a.pos)
       (Mapq.print a.mapq)
@@ -1385,7 +1385,7 @@ module Test = struct
   (*          cigar = "9M"; rnext = "*"; pnext = 7; tlen = -39; seq = "CAGCGCCAT"; *)
   (*          qual = "*"; optional = [("NM", 'i', "0")]}) *)
   (*     (`alignment *)
-  (*         {Sam.query_template_name = "r001"; flags = Sam.Flags.of_int 83; *)
+  (*         {Sam.query_template_name = "r001"; flag = Sam.Flag.of_int 83; *)
   (*          reference_sequence = `name "ref"; position = Some 37; *)
   (*          mapping_quality = Some 30; cigar_operations = [|`M 9|]; *)
   (*          next_reference_sequence = `qname; next_position = Some 7; *)
@@ -1396,7 +1396,7 @@ module Test = struct
   (*   assert_bool "last alignment" (Tfxm.next t = *)
   (*       `output (Ok *)
   (*                  (`alignment *)
-  (*                      {Sam.query_template_name = "chr0"; flags = Sam.Flags.of_int 83; *)
+  (*                      {Sam.query_template_name = "chr0"; flag = Sam.Flag.of_int 83; *)
   (*                       reference_sequence = *)
   (*                          `reference_sequence *)
   (*                            {Sam.ref_name = "chr0"; ref_length = 42; *)

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -1341,7 +1341,7 @@ module Alignment = struct
 end
 
 module Parser = struct
-  module Phase = struct
+  module State = struct
     type t =
       [ `Header of Header.Item_list_rev.t
       | `Alignment of Header.t * Alignment.t
@@ -1350,7 +1350,7 @@ module Parser = struct
 
   type 'a t =
     { parse_line : string -> 'a t Or_error.t
-    ; phase : Phase.t
+    ; state : State.t
     ; data : 'a
     ; on_alignment : 'a -> Header.t -> Alignment.t -> 'a
     }
@@ -1373,7 +1373,7 @@ module Parser = struct
 
   and make_header_parser ~on_alignment ~data items : 'a t =
     { parse_line = parse_header_line ~on_alignment ~data items
-    ; phase = `Header items
+    ; state = `Header items
     ; data
     ; on_alignment
     }
@@ -1387,7 +1387,7 @@ module Parser = struct
 
   and make_alignment_parser ~on_alignment ~data header alignment : 'a t =
     { parse_line = parse_alignment_line ~on_alignment ~data header
-    ; phase = `Alignment (header, alignment)
+    ; state = `Alignment (header, alignment)
     ; data
     ; on_alignment
     }
@@ -1397,17 +1397,17 @@ module Parser = struct
     make_header_parser ~on_alignment ~data Header.Item_list_rev.empty
   ;;
 
-  let reduce { parse_line; phase = _; data = _; on_alignment = _ } line = parse_line line
+  let reduce { parse_line; state = _; data = _; on_alignment = _ } line = parse_line line
   let reduce_exn x line = reduce x line |> Or_error.ok_exn
 
-  let header { phase; parse_line = _; data = _; on_alignment = _ } =
-    match phase with
+  let header { state; parse_line = _; data = _; on_alignment = _ } =
+    match state with
     | `Header items -> Header.of_item_list_rev items
     | `Alignment (header, _) -> Ok header
   ;;
 
   let header_exn x = header x |> Or_error.ok_exn
-  let phase x = x.phase
+  let state x = x.state
   let data x = x.data
 end
 

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -1340,7 +1340,7 @@ module Alignment = struct
   ;;
 end
 
-module State = struct
+module Parser = struct
   module Phase = struct
     type t =
       [ `Header of Header.Item_list_rev.t
@@ -1416,17 +1416,17 @@ let of_lines lines =
     match lines with
     | [] -> Ok state
     | line :: lines -> (
-      match State.reduce state line with
+      match Parser.reduce state line with
       | Error _ as e -> e
       | Ok state -> loop state lines)
   in
   let on_alignment data _header alignment = alignment :: data in
-  let init = State.init ~on_alignment ~data:[] in
+  let init = Parser.init ~on_alignment ~data:[] in
   match loop init lines with
   | Error _ as e -> e
   | Ok state -> (
-    let alignments = List.rev (State.data state) in
-    match State.header state with
+    let alignments = List.rev (Parser.data state) in
+    match Parser.header state with
     | Error _ as e -> e
     | Ok header -> Ok (header, alignments))
 ;;
@@ -1436,10 +1436,10 @@ let of_lines lines =
    [of_lines] above. *)
 let of_lines_exn lines =
   let on_alignment data _header alignment = alignment :: data in
-  let init = State.init ~on_alignment ~data:[] in
-  let state = List.fold lines ~init ~f:State.reduce_exn in
-  let header = State.header_exn state in
-  let alignments = List.rev (State.data state) in
+  let init = Parser.init ~on_alignment ~data:[] in
+  let state = List.fold lines ~init ~f:Parser.reduce_exn in
+  let header = Parser.header_exn state in
+  let alignments = List.rev (Parser.data state) in
   header, alignments
 ;;
 

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -567,7 +567,7 @@ module Header = struct
     ;;
   end
 
-  module Header_item = struct
+  module Item = struct
     type t =
       [ `HD of HD.t
       | `SQ of SQ.t

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -329,41 +329,41 @@ module Header = struct
     ;;
   end
 
-  module Platform = struct
-    type t =
-      [ `Capillary
-      | `LS454
-      | `Illumina
-      | `Solid
-      | `Helicos
-      | `Ion_Torrent
-      | `Pac_Bio
-      ]
-    [@@deriving sexp]
-
-    let parse = function
-      | "CAPILLARY" -> Ok `Capillary
-      | "LS454" -> Ok `LS454
-      | "ILLUMINA" -> Ok `Illumina
-      | "SOLID" -> Ok `Solid
-      | "HELICOS" -> Ok `Helicos
-      | "IONTORRENT" -> Ok `Ion_Torrent
-      | "PACBIO" -> Ok `Pac_Bio
-      | x -> Error (Error.create "unknown platform" x sexp_of_string)
-    ;;
-
-    let print = function
-      | `Capillary -> "CAPILLARY"
-      | `LS454 -> "LS454"
-      | `Illumina -> "ILLUMINA"
-      | `Solid -> "SOLID"
-      | `Helicos -> "HELICOS"
-      | `Ion_Torrent -> "IONTORRENT"
-      | `Pac_Bio -> "PACBIO"
-    ;;
-  end
-
   module RG = struct
+    module PL = struct
+      type t =
+        [ `Capillary
+        | `LS454
+        | `Illumina
+        | `Solid
+        | `Helicos
+        | `Ion_Torrent
+        | `Pac_Bio
+        ]
+      [@@deriving sexp]
+
+      let parse = function
+        | "CAPILLARY" -> Ok `Capillary
+        | "LS454" -> Ok `LS454
+        | "ILLUMINA" -> Ok `Illumina
+        | "SOLID" -> Ok `Solid
+        | "HELICOS" -> Ok `Helicos
+        | "IONTORRENT" -> Ok `Ion_Torrent
+        | "PACBIO" -> Ok `Pac_Bio
+        | x -> Error (Error.create "unknown platform" x sexp_of_string)
+      ;;
+
+      let print = function
+        | `Capillary -> "CAPILLARY"
+        | `LS454 -> "LS454"
+        | `Illumina -> "ILLUMINA"
+        | `Solid -> "SOLID"
+        | `Helicos -> "HELICOS"
+        | `Ion_Torrent -> "IONTORRENT"
+        | `Pac_Bio -> "PACBIO"
+      ;;
+    end
+
     type t =
       { id : string
       ; seq_center : string option
@@ -374,7 +374,7 @@ module Header = struct
       ; library : string option
       ; program : string option
       ; predicted_median_insert_size : int option
-      ; platform : Platform.t option
+      ; platform : PL.t option
       ; platform_unit : string option
       ; sample : string option
       }
@@ -472,7 +472,7 @@ module Header = struct
              sexp_of_string))
       >>= fun predicted_median_insert_size ->
       find01 `RG tvl "PL"
-      >>?~ Platform.parse
+      >>?~ PL.parse
       >>= fun platform ->
       find01 `RG tvl "PU"
       >>= fun platform_unit ->
@@ -516,7 +516,7 @@ module Header = struct
         (s "LB" x.library)
         (s "PG" x.program)
         (s "PI" (Option.map x.predicted_median_insert_size ~f:Int.to_string))
-        (s "PL" (Option.map x.platform ~f:Platform.print))
+        (s "PL" (Option.map x.platform ~f:PL.print))
         (s "PU" x.platform_unit)
         (s "SM" x.sample)
     ;;

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -623,7 +623,7 @@ module Header = struct
     ; read_groups : RG.t list
     ; programs : PG.t list
     ; comments : string list
-    ; others : (string * Tag_value.t list) list
+    ; others : Other.t list
     }
 
   let empty =

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -625,7 +625,7 @@ module Header = struct
     ; others : (string * Tag_value.t list) list
     }
 
-  let empty_header =
+  let empty =
     { version = None
     ; sort_order = None
     ; group_order = None

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -693,6 +693,12 @@ module Flags = struct
     else Error (Error.create "flag out of range" x sexp_of_int)
   ;;
 
+  let parse s =
+    try of_int (Int.of_string s) with
+    | _ -> Error (Error.create "invalid FLAG" s sexp_of_string)
+  ;;
+
+  let print = Int.to_string
   let flag_is_set s f = f land s <> 0
   let has_multiple_segments = flag_is_set 0x1
   let each_segment_properly_aligned = flag_is_set 0x2
@@ -1078,12 +1084,6 @@ module Alignment = struct
   ;;
 
   let parse_qname s = parse_opt_string "QNAME" qname_re s
-
-  let parse_flags s =
-    try Flags.of_int (Int.of_string s) with
-    | _ -> Error (Error.create "invalid FLAG" s sexp_of_string)
-  ;;
-
   let rname_re = Re.Perl.compile_pat "^\\*|[!-()+-<>-~][!-~]*$"
   let parse_rname s = parse_opt_string "RNAME" rname_re s
 
@@ -1141,7 +1141,7 @@ module Alignment = struct
       :: optional_fields ->
       parse_qname qname
       >>= fun qname ->
-      parse_flags flags
+      Flags.parse flags
       >>= fun flags ->
       parse_rname rname
       >>= fun rname ->
@@ -1186,8 +1186,6 @@ module Alignment = struct
     | None -> "*"
   ;;
 
-  let print_flags = Int.to_string
-
   let print_rname = function
     | Some x -> x
     | None -> "*"
@@ -1230,7 +1228,7 @@ module Alignment = struct
     sprintf
       "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
       (print_qname a.qname)
-      (print_flags a.flags)
+      (Flags.print a.flags)
       (print_rname a.rname)
       (print_pos a.pos)
       (print_mapq a.mapq)

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -1397,8 +1397,8 @@ module Parser = struct
     make_header_parser ~on_alignment ~data Header.Item_list_rev.empty
   ;;
 
-  let reduce { parse_line; state = _; data = _; on_alignment = _ } line = parse_line line
-  let reduce_exn x line = reduce x line |> Or_error.ok_exn
+  let step { parse_line; state = _; data = _; on_alignment = _ } line = parse_line line
+  let step_exn x line = step x line |> Or_error.ok_exn
 
   let header { state; parse_line = _; data = _; on_alignment = _ } =
     match state with
@@ -1416,7 +1416,7 @@ let of_lines lines =
     match lines with
     | [] -> Ok parser
     | line :: lines -> (
-      match Parser.reduce parser line with
+      match Parser.step parser line with
       | Error _ as e -> e
       | Ok parser -> loop parser lines)
   in
@@ -1432,12 +1432,12 @@ let of_lines lines =
 ;;
 
 (* We could implement this as [of_lines |> ok_exn], but we also want to demonstrate
-   how to use [reduce_exn] versus [reduce] to contrast with the implementation of
+   how to use [step_exn] versus [step] to contrast with the implementation of
    [of_lines] above. *)
 let of_lines_exn lines =
   let on_alignment data _header alignment = alignment :: data in
   let init = Parser.init ~on_alignment ~data:[] in
-  let parser = List.fold lines ~init ~f:Parser.reduce_exn in
+  let parser = List.fold lines ~init ~f:Parser.step_exn in
   let header = Parser.header_exn parser in
   let alignments = List.rev (Parser.data parser) in
   header, alignments

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -736,16 +736,30 @@ module Header = struct
         ()
   ;;
 
-  let num_items t =
-    List.length t.ref_seqs
-    + List.length t.read_groups
-    + List.length t.programs
-    + List.length t.comments
-    + List.length t.others
-    +
-    match t.version with
-    | None -> 0
-    | Some _ -> 1
+  let to_items
+        { version
+        ; sort_order
+        ; group_order
+        ; ref_seqs
+        ; read_groups
+        ; programs
+        ; comments
+        ; others
+        }
+    =
+    let hd =
+      match version with
+      | None -> []
+      | Some version -> [ `HD { HD.version; sort_order; group_order } ]
+    in
+    List.concat
+      [ hd
+      ; List.map ref_seqs ~f:(fun x -> `SQ x)
+      ; List.map read_groups ~f:(fun x -> `RG x)
+      ; List.map programs ~f:(fun x -> `PG x)
+      ; List.map comments ~f:(fun x -> `CO x)
+      ; List.map others ~f:(fun x -> `Other x)
+      ]
   ;;
 end
 

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -616,7 +616,7 @@ module Header = struct
   end
 
   type t =
-    { version : string option
+    { version : HD.VN.t option
     ; sort_order : HD.SO.t option
     ; group_order : HD.GO.t option
     ; ref_seqs : SQ.t list

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -567,6 +567,17 @@ module Header = struct
     ;;
   end
 
+  module Other = struct
+    type t = string * Tag_value.t list [@@deriving sexp]
+
+    let print ((tag, l) : t) =
+      sprintf
+        "@%s%s"
+        tag
+        (List.map l ~f:(fun (x, y) -> sprintf "\t%s:%s" x y) |> String.concat ~sep:"")
+    ;;
+  end
+
   module Item = struct
     type t =
       [ `HD of HD.t
@@ -574,7 +585,7 @@ module Header = struct
       | `RG of RG.t
       | `PG of PG.t
       | `CO of string
-      | `Other of string * Tag_value.t list
+      | `Other of Other.t
       ]
     [@@deriving sexp]
 
@@ -602,14 +613,6 @@ module Header = struct
             Result_list.map tvl ~f:Tag_value.parse >>= fun tvl -> parse_data tag tvl))
     ;;
   end
-
-  (** TODO(ashish): This function appears to be unused. Should we delete it? *)
-  let print_other ((tag, l) : string * Tag_value.t list) =
-    sprintf
-      "@%s%s"
-      tag
-      (List.map l ~f:(fun (x, y) -> sprintf "\t%s:%s" x y) |> String.concat ~sep:"")
-  ;;
 
   type t =
     { version : string option

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -589,7 +589,7 @@ module Header = struct
       ]
     [@@deriving sexp]
 
-    let t_of_line line =
+    let t_of_string line =
       let parse_data tag tvl =
         match tag with
         | `HD -> HD.t_of_tag_value_list tvl >>| fun x -> `HD x
@@ -599,8 +599,8 @@ module Header = struct
         | `Other tag -> Ok (`Other (tag, tvl))
         | `CO -> assert false
       in
-      match String.lsplit2 ~on:'\t' (line : Line.t :> string) with
-      | None -> Error (Error.create "header line contains no tabs" line Line.sexp_of_t)
+      match String.lsplit2 ~on:'\t' line with
+      | None -> Error (Error.create "header line contains no tabs" line sexp_of_string)
       | Some (tag, data) -> (
         Type.t_of_string tag
         >>= function
@@ -1201,8 +1201,8 @@ module Alignment = struct
     | errs -> Error (Error.of_list errs)
   ;;
 
-  let t_of_line ?ref_seqs line =
-    match String.split ~on:'\t' (line : Line.t :> string) with
+  let t_of_string ?ref_seqs line =
+    match String.split ~on:'\t' line with
     | qname
       :: flag
       :: rname

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -225,9 +225,7 @@ module Header = struct
       }
     [@@deriving sexp]
 
-    let make ~version ?sort_order ?group_order () =
-      VN.of_string version >>| fun version -> { version; sort_order; group_order }
-    ;;
+    let make ~version ?sort_order ?group_order () = { version; sort_order; group_order }
 
     let of_tag_value_list tvl =
       Tag_value.find1 `HD tvl "VN"
@@ -239,7 +237,7 @@ module Header = struct
       >>?~ GO.of_string
       >>= fun group_order ->
       Tag_value.assert_tags `HD tvl [ "VN"; "SO"; "GO" ]
-      >>= fun () -> make ~version ?sort_order ?group_order ()
+      >>| fun () -> make ~version ?sort_order ?group_order ()
     ;;
 
     let to_string { version; sort_order; group_order } =

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -1407,6 +1407,8 @@ module State = struct
   ;;
 
   let header_exn x = header x |> Or_error.ok_exn
+  let phase x = x.phase
+  let data x = x.data
 end
 
 let of_lines lines =
@@ -1422,7 +1424,7 @@ let of_lines lines =
   match loop (State.init ~on_alignment ~data:[]) lines with
   | Error _ as e -> e
   | Ok state -> (
-    let alignments = List.rev state.data in
+    let alignments = List.rev (State.data state) in
     match State.header state with
     | Error _ as e -> e
     | Ok header -> Ok (header, alignments))
@@ -1437,7 +1439,7 @@ let of_lines_exn lines =
     List.fold lines ~init:(State.init ~on_alignment ~data:[]) ~f:State.reduce_exn
   in
   let header = State.header_exn state in
-  let alignments = List.rev state.data in
+  let alignments = List.rev (State.data state) in
   header, alignments
 ;;
 

--- a/lib/base/sam.ml
+++ b/lib/base/sam.ml
@@ -736,6 +736,18 @@ module Header = struct
         ~others
         ()
   ;;
+
+  let num_items t =
+    List.length t.ref_seqs
+    + List.length t.read_groups
+    + List.length t.programs
+    + List.length t.comments
+    + List.length t.others
+    +
+    match t.version with
+    | None -> 0
+    | Some _ -> 1
+  ;;
 end
 
 let parse_int_range field lo hi s =

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -4,7 +4,7 @@
 open! Import
 
 module Header : sig
-  module Header_item_tag : sig
+  module Type : sig
     (** Header item tags define the different types of header lines. The
     term "tag" in this context should not be confused with its use in
     "tag-value" pairs, which comprise the content of header items. *)

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -242,6 +242,8 @@ module Flags : sig
   type t = private int [@@deriving sexp]
 
   val of_int : int -> t Or_error.t
+  val parse : string -> t Or_error.t
+  val print : t -> string
   val has_multiple_segments : t -> bool
   val each_segment_properly_aligned : t -> bool
   val segment_unmapped : t -> bool
@@ -375,7 +377,6 @@ module Alignment : sig
     -> t Or_error.t
 
   val parse_qname : string -> string option Or_error.t
-  val parse_flags : string -> Flags.t Or_error.t
   val parse_rname : string -> string option Or_error.t
   val parse_pos : string -> int option Or_error.t
   val parse_mapq : string -> int option Or_error.t
@@ -390,7 +391,6 @@ module Alignment : sig
     -> t Or_error.t
 
   val print_qname : string option -> string
-  val print_flags : Flags.t -> string
   val print_rname : string option -> string
   val print_pos : int option -> string
   val print_mapq : int option -> string

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -55,7 +55,7 @@ module Header : sig
     end
 
     module VN : sig
-      type t = string [@@deriving sexp]
+      type t = private string [@@deriving sexp]
 
       val of_string : string -> t Or_error.t
       val to_string : t -> string
@@ -67,15 +67,8 @@ module Header : sig
       ; group_order : GO.t option
       }
     [@@deriving sexp]
-    (* FIXME: Make the type private. Removed temporarily to fix build. *)
 
-    val make
-      :  version:VN.t
-      -> ?sort_order:SO.t
-      -> ?group_order:GO.t
-      -> unit
-      -> t Or_error.t
-
+    val make : version:VN.t -> ?sort_order:SO.t -> ?group_order:GO.t -> unit -> t
     val of_tag_value_list : Tag_value.t list -> t Or_error.t
     val to_string : t -> string
   end
@@ -184,8 +177,7 @@ module Header : sig
 
   module Item : sig
     type t =
-      private
-      [< `HD of HD.t
+      [ `HD of HD.t
       | `SQ of SQ.t
       | `RG of RG.t
       | `PG of PG.t
@@ -229,7 +221,7 @@ module Header : sig
 end
 
 module Qname : sig
-  type t = string [@@deriving sexp]
+  type t = private string [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
   val to_string_option : t option -> string

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -5,9 +5,6 @@ open! Import
 
 module Header : sig
   module Type : sig
-    (** Header item tags define the different types of header lines. The
-    term "tag" in this context should not be confused with its use in
-    "tag-value" pairs, which comprise the content of header items. *)
     type t =
       private
       [< `HD
@@ -64,10 +61,6 @@ module Header : sig
       val print : string -> string
     end
 
-    (** @HD. A header consists of different types of lines. Confusingly, one of
-      these types is called {i the} "header line", which is what this
-      type refers to. It does not refer generically to any line within a
-      header. *)
     type t =
       { version : VN.t
       ; sort_order : SO.t option
@@ -88,7 +81,6 @@ module Header : sig
   end
 
   module SQ : sig
-    (** @SQ. Reference sequence. *)
     type t = private
       { name : string (** SN *)
       ; length : int (** LN *)
@@ -130,7 +122,6 @@ module Header : sig
   end
 
   module RG : sig
-    (** @RG. *)
     type t = private
       { id : string (** ID *)
       ; seq_center : string option (** CN *)
@@ -171,7 +162,6 @@ module Header : sig
   end
 
   module PG : sig
-    (** @PG. *)
     type t = private
       { id : string (** ID *)
       ; name : string option (** PN *)

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -461,7 +461,7 @@ module Alignment : sig
   val string_of_t : t -> string
 end
 
-module State : sig
+module Parser : sig
   (** State-machine based parser. *)
 
   module Phase : sig

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -462,7 +462,7 @@ module Alignment : sig
 end
 
 module Parser : sig
-  (** State-machine based parser. *)
+  (** State-machine based line-oriented parser. *)
 
   module State : sig
     type t =
@@ -473,9 +473,14 @@ module Parser : sig
 
   type 'a t
 
+  (** [init ~on_alignment ~data] produces an initial parser, ready to parse the
+      first line of a SAM file with initial data set to [data]. The callback
+      [on_alignment] is called on the result of parsing each alignment line,
+      and updates the data. *)
   val init : on_alignment:('a -> Header.t -> Alignment.t -> 'a) -> data:'a -> 'a t
-  val reduce : 'a t -> string -> 'a t Or_error.t
-  val reduce_exn : 'a t -> string -> 'a t
+
+  val step : 'a t -> string -> 'a t Or_error.t
+  val step_exn : 'a t -> string -> 'a t
 
   (** [header t] returns the header parsed thus far given current state [t]. *)
   val header : _ t -> Header.t Or_error.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -471,12 +471,7 @@ module State : sig
       ]
   end
 
-  type 'a t =
-    { parse_line : string -> 'a t Or_error.t
-    ; phase : Phase.t
-    ; data : 'a
-    ; on_alignment : 'a -> Header.t -> Alignment.t -> 'a
-    }
+  type 'a t
 
   val init : on_alignment:('a -> Header.t -> Alignment.t -> 'a) -> data:'a -> 'a t
   val reduce : 'a t -> string -> 'a t Or_error.t
@@ -486,6 +481,8 @@ module State : sig
   val header : _ t -> Header.t Or_error.t
 
   val header_exn : _ t -> Header.t
+  val phase : _ t -> Phase.t
+  val data : 'a t -> 'a
 end
 
 (** [of_lines lines] parses the given [lines] of a SAM file. *)

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -57,17 +57,21 @@ module Header : sig
       val print : t -> string
     end
 
-    val parse_header_version : string -> string Or_error.t
-    val print_header_version : string -> string
+    module VN : sig
+      type t = string [@@deriving sexp]
+
+      val parse : string -> string Or_error.t
+      val print : string -> string
+    end
 
     (** @HD. A header consists of different types of lines. Confusingly, one of
       these types is called {i the} "header line", which is what this
       type refers to. It does not refer generically to any line within a
       header. *)
     type t =
-      { version : string (** VN *)
-      ; sort_order : SO.t option (** SO *)
-      ; group_order : GO.t option (** GO *)
+      { version : VN.t
+      ; sort_order : SO.t option
+      ; group_order : GO.t option
       }
     [@@deriving sexp]
     (* FIXME: Make the type private. Removed temporarily to fix build. *)

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -250,6 +250,11 @@ module Header : sig
 
   (** [of_item_list_rev items] takes a list of header items in reverse order. *)
   val of_item_list_rev : Item_list_rev.t -> t Or_error.t
+
+  (** [num_items t] is the number of header lines that [t] logically
+      consists of, i.e. the number of header lines that it was derived
+      from or that it would print to. *)
+  val num_items : t -> int
 end
 
 module Qname : sig

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -462,6 +462,8 @@ module Alignment : sig
 end
 
 module State : sig
+  (** State-machine based parser. *)
+
   type t =
     { parse_line : string -> t Or_error.t
     ; data : [ `Header of Header.Item_list_rev.t | `Alignment of Header.t * Alignment.t ]
@@ -469,4 +471,20 @@ module State : sig
 
   val init : t
   val reduce : t -> string -> t Or_error.t
+  val reduce_exn : t -> string -> t
+
+  (** [header t] returns the header parsed thus far given current state [t]. *)
+  val header : t -> Header.t Or_error.t
+
+  val header_exn : t -> Header.t
 end
+
+(** [of_lines lines] parses the given [lines] of a SAM file. *)
+val of_lines : string list -> (Header.t * Alignment.t list) Or_error.t
+
+val of_lines_exn : string list -> Header.t * Alignment.t list
+
+(** [of_string content] parses the given [content] of a SAM file. *)
+val of_string : string -> (Header.t * Alignment.t list) Or_error.t
+
+val of_string_exn : string -> Header.t * Alignment.t list

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -204,11 +204,7 @@ module Header : sig
   type t = private Item.t list [@@deriving sexp]
 
   val of_items : Item.t list -> t Or_error.t
-
-  (** [of_lines lines] parses [lines] through all header lines. Returns the
-      header and any remaining lines, which are presumably alignment lines. *)
-  val of_lines : string list -> (t * string list) Or_error.t
-
+  val of_lines : string list -> t Or_error.t
   val hd : t -> HD.t option
   val version : t -> HD.VN.t option
   val sort_order : t -> HD.SO.t option
@@ -452,12 +448,15 @@ module Parser : sig
   val data : 'a t -> 'a
 end
 
+(** [must_be_header line] returns true if the first character of [line] is '@',
+    quickly determining that it must be parsed as a header line. *)
+val must_be_header : string -> bool
+
 (** [of_lines lines] parses the given [lines] of a SAM file. *)
 val of_lines : string list -> (Header.t * Alignment.t list) Or_error.t
 
 val of_lines2 : string list -> (Header.t * Alignment.t list) Or_error.t
 val of_lines_exn : string list -> Header.t * Alignment.t list
-val of_lines2_exn : string list -> Header.t * Alignment.t list
 
 (** [of_string content] parses the given [content] of a SAM file. *)
 val of_string : string -> (Header.t * Alignment.t list) Or_error.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -194,7 +194,7 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val t_of_line : Line.t -> t Or_error.t
+    val t_of_string : string -> t Or_error.t
   end
 
   (**
@@ -433,9 +433,9 @@ module Alignment : sig
     -> unit
     -> t Or_error.t
 
-  val t_of_line
+  val t_of_string
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
-    -> Line.t
+    -> string
     -> t Or_error.t
 
   val string_of_t : t -> string

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -464,24 +464,28 @@ end
 module State : sig
   (** State-machine based parser. *)
 
-  type node =
-    [ `Header of Header.Item_list_rev.t
-    | `Alignment of Header.t * Alignment.t
-    ]
+  module Phase : sig
+    type t =
+      [ `Header of Header.Item_list_rev.t
+      | `Alignment of Header.t * Alignment.t
+      ]
+  end
 
-  type t
+  type 'a t =
+    { parse_line : string -> 'a t Or_error.t
+    ; phase : Phase.t
+    ; data : 'a
+    ; on_alignment : 'a -> Header.t -> Alignment.t -> 'a
+    }
 
-  val init : t
-  val reduce : t -> string -> t Or_error.t
-  val reduce_exn : t -> string -> t
-
-  (** [node t] returns the node attached to given state [t]. *)
-  val node : t -> node
+  val init : on_alignment:('a -> Header.t -> Alignment.t -> 'a) -> data:'a -> 'a t
+  val reduce : 'a t -> string -> 'a t Or_error.t
+  val reduce_exn : 'a t -> string -> 'a t
 
   (** [header t] returns the header parsed thus far given current state [t]. *)
-  val header : t -> Header.t Or_error.t
+  val header : _ t -> Header.t Or_error.t
 
-  val header_exn : t -> Header.t
+  val header_exn : _ t -> Header.t
 end
 
 (** [of_lines lines] parses the given [lines] of a SAM file. *)

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -197,6 +197,17 @@ module Header : sig
     val t_of_string : string -> t Or_error.t
   end
 
+  module Item_list_rev : sig
+    (** Header lines stored in a list with items in reverse order. *)
+    type t = private Item.t list [@@deriving sexp]
+
+    val empty : t
+
+    (** [append t x] appends [x] to [t]. It is logically the last item,
+        but stored as the first item in the list underlying [t]. *)
+    val append : t -> Item.t -> t
+  end
+
   (**
      - [sort_order]: Guaranteed to be [None] if [version = None].
 
@@ -238,7 +249,7 @@ module Header : sig
     -> t Or_error.t
 
   (** [of_item_list_rev items] takes a list of header items in reverse order. *)
-  val of_item_list_rev : Item.t list -> t Or_error.t
+  val of_item_list_rev : Item_list_rev.t -> t Or_error.t
 end
 
 module Qname : sig
@@ -447,7 +458,7 @@ end
 
 module State : sig
   type t =
-    [ `Header of Header.Item.t list
+    [ `Header of Header.Item_list_rev.t
     | `Alignment of Header.t * Alignment.t
     ]
   [@@deriving sexp]

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -3,10 +3,6 @@
     specification}. *)
 open! Import
 
-(** {2 Types} *)
-
-(** {3 Header Types} *)
-
 module Header : sig
   module Header_item_tag : sig
     (** Header item tags define the different types of header lines. The
@@ -239,8 +235,6 @@ module Header : sig
     -> unit
     -> t Or_error.t
 end
-
-(** {3 Alignment Types} *)
 
 module Flags : sig
   (** Flags are represented as a "bit map". *)

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -405,7 +405,7 @@ module Alignment : sig
     ; flag : Flag.t (** FLAG *)
     ; rname : Rname.t option (** RNAME *)
     ; pos : Pos.t option (** POS *)
-    ; mapq : int option (** MAPQ *)
+    ; mapq : Mapq.t option (** MAPQ *)
     ; cigar : Cigar.t (** CIGAR *)
     ; rnext : Rnext.t option (** RNEXT *)
     ; pnext : Pnext.t option (** PNEXT *)
@@ -422,11 +422,11 @@ module Alignment : sig
     -> flag:Flag.t
     -> ?rname:Rname.t
     -> ?pos:Pos.t
-    -> ?mapq:int
+    -> ?mapq:Mapq.t
     -> ?cigar:Cigar.t
     -> ?rnext:Rnext.t
     -> ?pnext:Pnext.t
-    -> ?tlen:int
+    -> ?tlen:Tlen.t
     -> ?seq:Seq.t
     -> ?qual:Qual.t
     -> ?optional_fields:Optional_field.t list

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -218,7 +218,7 @@ module Header : sig
     ; read_groups : RG.t list
     ; programs : PG.t list
     ; comments : string list
-    ; others : (string * Tag_value.t list) list
+    ; others : Other.t list
     }
   (* FIXME: Make the type private. Removed temporarily to fix build. *)
 
@@ -232,7 +232,7 @@ module Header : sig
     -> ?read_groups:RG.t list
     -> ?programs:PG.t list
     -> ?comments:string list
-    -> ?others:(string * Tag_value.t list) list
+    -> ?others:Other.t list
     -> unit
     -> t Or_error.t
 end

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -248,6 +248,10 @@ module Header : sig
   (** [of_item_list_rev items] takes a list of header items in reverse order. *)
   val of_item_list_rev : Item_list_rev.t -> t Or_error.t
 
+  (** [of_lines lines] parses [lines] through all header lines. Returns the
+      header and any remaining lines, which are presumably alignment lines. *)
+  val of_lines : string list -> (t * string list) Or_error.t
+
   val to_items : t -> Item.t list
 end
 
@@ -487,7 +491,9 @@ end
 (** [of_lines lines] parses the given [lines] of a SAM file. *)
 val of_lines : string list -> (Header.t * Alignment.t list) Or_error.t
 
+val of_lines2 : string list -> (Header.t * Alignment.t list) Or_error.t
 val of_lines_exn : string list -> Header.t * Alignment.t list
+val of_lines2_exn : string list -> Header.t * Alignment.t list
 
 (** [of_string content] parses the given [content] of a SAM file. *)
 val of_string : string -> (Header.t * Alignment.t list) Or_error.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -211,7 +211,7 @@ module Header : sig
      - [comments]: Unordered list of @CO lines.
   *)
   type t =
-    { version : string option
+    { version : HD.VN.t option
     ; sort_order : HD.SO.t option
     ; group_order : HD.GO.t option
     ; ref_seqs : SQ.t list

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -105,23 +105,23 @@ module Header : sig
     val print : t -> string
   end
 
-  module Platform : sig
-    type t =
-      [ `Capillary
-      | `LS454
-      | `Illumina
-      | `Solid
-      | `Helicos
-      | `Ion_Torrent
-      | `Pac_Bio
-      ]
-    [@@deriving sexp]
-
-    val parse : string -> t Or_error.t
-    val print : t -> string
-  end
-
   module RG : sig
+    module PL : sig
+      type t =
+        [ `Capillary
+        | `LS454
+        | `Illumina
+        | `Solid
+        | `Helicos
+        | `Ion_Torrent
+        | `Pac_Bio
+        ]
+      [@@deriving sexp]
+
+      val parse : string -> t Or_error.t
+      val print : t -> string
+    end
+
     type t = private
       { id : string (** ID *)
       ; seq_center : string option (** CN *)
@@ -132,7 +132,7 @@ module Header : sig
       ; library : string option (** LB *)
       ; program : string option (** PG *)
       ; predicted_median_insert_size : int option (** PI *)
-      ; platform : Platform.t option (** PL *)
+      ; platform : PL.t option (** PL *)
       ; platform_unit : string option (** PU *)
       ; sample : string option (** SM *)
       }
@@ -151,7 +151,7 @@ module Header : sig
       -> ?library:string
       -> ?program:string
       -> ?predicted_median_insert_size:int
-      -> ?platform:Platform.t
+      -> ?platform:PL.t
       -> ?platform_unit:string
       -> ?sample:string
       -> unit

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -265,6 +265,27 @@ module Flags : sig
   val supplementary_alignment : t -> bool
 end
 
+module Rname : sig
+  type t = string [@@deriving sexp]
+
+  val parse : string -> string option Or_error.t
+  val print : string option -> string
+end
+
+module Pos : sig
+  type t = int [@@deriving sexp]
+
+  val parse : string -> int option Or_error.t
+  val print : int option -> string
+end
+
+module Mapq : sig
+  type t = int [@@deriving sexp]
+
+  val parse : string -> int option Or_error.t
+  val print : int option -> string
+end
+
 module Cigar : sig
   module Op : sig
     (** CIGAR operations. *)
@@ -312,6 +333,34 @@ module Rnext : sig
   val print : t option -> string
 end
 
+module Pnext : sig
+  type t = int [@@deriving sexp]
+
+  val parse : string -> int option Or_error.t
+  val print : int option -> string
+end
+
+module Tlen : sig
+  type t = int [@@deriving sexp]
+
+  val parse : string -> int option Or_error.t
+  val print : int option -> string
+end
+
+module Seq : sig
+  type t = string [@@deriving sexp]
+
+  val parse : string -> string option Or_error.t
+  val print : string option -> string
+end
+
+module Qual : sig
+  type t = Phred_score.t list [@@deriving sexp]
+
+  val parse : string -> Phred_score.t list Or_error.t
+  val print : Phred_score.t list -> string
+end
+
 module Optional_field : sig
   module Value : sig
     (** The constructor encodes the TYPE and each carries its
@@ -353,15 +402,15 @@ module Alignment : sig
   type t = private
     { qname : Qname.t option (** QNAME *)
     ; flags : Flags.t (** FLAG *)
-    ; rname : string option (** RNAME *)
-    ; pos : int option (** POS *)
+    ; rname : Rname.t option (** RNAME *)
+    ; pos : Pos.t option (** POS *)
     ; mapq : int option (** MAPQ *)
     ; cigar : Cigar.t (** CIGAR *)
     ; rnext : Rnext.t option (** RNEXT *)
-    ; pnext : int option (** PNEXT *)
-    ; tlen : int option (** TLEN *)
-    ; seq : string option (** SEQ *)
-    ; qual : Phred_score.t list (** QUAL *)
+    ; pnext : Pnext.t option (** PNEXT *)
+    ; tlen : Tlen.t option (** TLEN *)
+    ; seq : Seq.t option (** SEQ *)
+    ; qual : Qual.t (** QUAL *)
     ; optional_fields : Optional_field.t list
     }
   [@@deriving sexp]
@@ -370,38 +419,23 @@ module Alignment : sig
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> ?qname:Qname.t
     -> flags:Flags.t
-    -> ?rname:string
-    -> ?pos:int
+    -> ?rname:Rname.t
+    -> ?pos:Pos.t
     -> ?mapq:int
     -> ?cigar:Cigar.t
     -> ?rnext:Rnext.t
-    -> ?pnext:int
+    -> ?pnext:Pnext.t
     -> ?tlen:int
-    -> ?seq:string
-    -> ?qual:Phred_score.t list
+    -> ?seq:Seq.t
+    -> ?qual:Qual.t
     -> ?optional_fields:Optional_field.t list
     -> unit
     -> t Or_error.t
-
-  val parse_rname : string -> string option Or_error.t
-  val parse_pos : string -> int option Or_error.t
-  val parse_mapq : string -> int option Or_error.t
-  val parse_pnext : string -> int option Or_error.t
-  val parse_tlen : string -> int option Or_error.t
-  val parse_seq : string -> string option Or_error.t
-  val parse_qual : string -> Phred_score.t list Or_error.t
 
   val parse
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> Line.t
     -> t Or_error.t
 
-  val print_rname : string option -> string
-  val print_pos : int option -> string
-  val print_mapq : int option -> string
-  val print_pnext : int option -> string
-  val print_tlen : int option -> string
-  val print_seq : string option -> string
-  val print_qual : Phred_score.t list -> string
   val print : t -> string
 end

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -464,14 +464,19 @@ end
 module State : sig
   (** State-machine based parser. *)
 
-  type t =
-    { parse_line : string -> t Or_error.t
-    ; data : [ `Header of Header.Item_list_rev.t | `Alignment of Header.t * Alignment.t ]
-    }
+  type data =
+    [ `Header of Header.Item_list_rev.t
+    | `Alignment of Header.t * Alignment.t
+    ]
+
+  type t
 
   val init : t
   val reduce : t -> string -> t Or_error.t
   val reduce_exn : t -> string -> t
+
+  (** [data t] returns the data attached to given state [t]. *)
+  val data : t -> data
 
   (** [header t] returns the header parsed thus far given current state [t]. *)
   val header : t -> Header.t Or_error.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -464,7 +464,7 @@ end
 module State : sig
   (** State-machine based parser. *)
 
-  type data =
+  type node =
     [ `Header of Header.Item_list_rev.t
     | `Alignment of Header.t * Alignment.t
     ]
@@ -475,8 +475,8 @@ module State : sig
   val reduce : t -> string -> t Or_error.t
   val reduce_exn : t -> string -> t
 
-  (** [data t] returns the data attached to given state [t]. *)
-  val data : t -> data
+  (** [node t] returns the node attached to given state [t]. *)
+  val node : t -> node
 
   (** [header t] returns the header parsed thus far given current state [t]. *)
   val header : t -> Header.t Or_error.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -237,6 +237,13 @@ module Header : sig
     -> t Or_error.t
 end
 
+module Qname : sig
+  type t = string [@@deriving sexp]
+
+  val parse : string -> t option Or_error.t
+  val print : t option -> string
+end
+
 module Flags : sig
   (** Flags are represented as a "bit map". *)
   type t = private int [@@deriving sexp]
@@ -344,7 +351,7 @@ module Alignment : sig
   (** For [cigar] and [qual], empty list indicates no value, i.e. '*',
     was given. *)
   type t = private
-    { qname : string option (** QNAME *)
+    { qname : Qname.t option (** QNAME *)
     ; flags : Flags.t (** FLAG *)
     ; rname : string option (** RNAME *)
     ; pos : int option (** POS *)
@@ -361,7 +368,7 @@ module Alignment : sig
 
   val make
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
-    -> ?qname:string
+    -> ?qname:Qname.t
     -> flags:Flags.t
     -> ?rname:string
     -> ?pos:int
@@ -376,7 +383,6 @@ module Alignment : sig
     -> unit
     -> t Or_error.t
 
-  val parse_qname : string -> string option Or_error.t
   val parse_rname : string -> string option Or_error.t
   val parse_pos : string -> int option Or_error.t
   val parse_mapq : string -> int option Or_error.t
@@ -390,7 +396,6 @@ module Alignment : sig
     -> Line.t
     -> t Or_error.t
 
-  val print_qname : string option -> string
   val print_rname : string option -> string
   val print_pos : int option -> string
   val print_mapq : int option -> string

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -70,7 +70,7 @@ module Header : sig
     (* FIXME: Make the type private. Removed temporarily to fix build. *)
 
     val make
-      :  version:string
+      :  version:VN.t
       -> ?sort_order:SO.t
       -> ?group_order:GO.t
       -> unit

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -76,7 +76,7 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val of_tag_value_list : Tag_value.t list -> t Or_error.t
     val to_string : t -> string
   end
 
@@ -101,7 +101,7 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val of_tag_value_list : Tag_value.t list -> t Or_error.t
     val to_string : t -> string
   end
 
@@ -157,7 +157,7 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val of_tag_value_list : Tag_value.t list -> t Or_error.t
     val to_string : t -> string
   end
 
@@ -172,7 +172,7 @@ module Header : sig
       }
     [@@deriving sexp]
 
-    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val of_tag_value_list : Tag_value.t list -> t Or_error.t
     val to_string : t -> string
   end
 
@@ -397,12 +397,12 @@ module Optional_field : sig
       ]
     [@@deriving sexp]
 
-    val t_of_char_A : char -> t Or_error.t
-    val t_of_int64_i : Int64.t -> t
-    val t_of_float_f : float -> t
+    val of_char_A : char -> t Or_error.t
+    val of_int64_i : Int64.t -> t
+    val of_float_f : float -> t
     val of_string_Z : string -> t Or_error.t
     val of_string_H : string -> t Or_error.t
-    val t_of_char_string_list_B : char -> string list -> t Or_error.t
+    val of_char_string_list_B : char -> string list -> t Or_error.t
     val of_string : string -> t Or_error.t
   end
 

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -261,20 +261,38 @@ module Flags : sig
   val supplementary_alignment : t -> bool
 end
 
-(** CIGAR operations. *)
-type cigar_op =
-  private
-  [< `Alignment_match of int
-  | `Insertion of int
-  | `Deletion of int
-  | `Skipped of int
-  | `Soft_clipping of int
-  | `Hard_clipping of int
-  | `Padding of int
-  | `Seq_match of int
-  | `Seq_mismatch of int
-  ]
-[@@deriving sexp]
+module Cigar_op : sig
+  (** CIGAR operations. *)
+  type t =
+    private
+    [< `Alignment_match of int
+    | `Insertion of int
+    | `Deletion of int
+    | `Skipped of int
+    | `Soft_clipping of int
+    | `Hard_clipping of int
+    | `Padding of int
+    | `Seq_match of int
+    | `Seq_mismatch of int
+    ]
+  [@@deriving sexp]
+
+  val parse_cigar : string -> t list Or_error.t
+  val print_cigar_op : t -> string
+  val print_cigar : t list -> string
+
+  (** {3 Low-level Optional field Parsers and Constructors} *)
+
+  val cigar_op_alignment_match : int -> t Or_error.t
+  val cigar_op_insertion : int -> t Or_error.t
+  val cigar_op_deletion : int -> t Or_error.t
+  val cigar_op_skipped : int -> t Or_error.t
+  val cigar_op_soft_clipping : int -> t Or_error.t
+  val cigar_op_hard_clipping : int -> t Or_error.t
+  val cigar_op_padding : int -> t Or_error.t
+  val cigar_op_seq_match : int -> t Or_error.t
+  val cigar_op_seq_mismatch : int -> t Or_error.t
+end
 
 (** The constructor encodes the TYPE and each carries its
     corresponding VALUE. *)
@@ -310,7 +328,7 @@ type alignment = private
   ; rname : string option (** RNAME *)
   ; pos : int option (** POS *)
   ; mapq : int option (** MAPQ *)
-  ; cigar : cigar_op list (** CIGAR *)
+  ; cigar : Cigar_op.t list (** CIGAR *)
   ; rnext : rnext option (** RNEXT *)
   ; pnext : int option (** PNEXT *)
   ; tlen : int option (** TLEN *)
@@ -321,18 +339,6 @@ type alignment = private
 [@@deriving sexp]
 
 (** {2 Low-level Parsers and Constructors} *)
-
-(** {3 Low-level Optional field Parsers and Constructors} *)
-
-val cigar_op_alignment_match : int -> cigar_op Or_error.t
-val cigar_op_insertion : int -> cigar_op Or_error.t
-val cigar_op_deletion : int -> cigar_op Or_error.t
-val cigar_op_skipped : int -> cigar_op Or_error.t
-val cigar_op_soft_clipping : int -> cigar_op Or_error.t
-val cigar_op_hard_clipping : int -> cigar_op Or_error.t
-val cigar_op_padding : int -> cigar_op Or_error.t
-val cigar_op_seq_match : int -> cigar_op Or_error.t
-val cigar_op_seq_mismatch : int -> cigar_op Or_error.t
 
 (** {3 Low-level Optional field Parsers and Constructors} *)
 
@@ -355,7 +361,7 @@ val alignment
   -> ?rname:string
   -> ?pos:int
   -> ?mapq:int
-  -> ?cigar:cigar_op list
+  -> ?cigar:Cigar_op.t list
   -> ?rnext:rnext
   -> ?pnext:int
   -> ?tlen:int
@@ -370,7 +376,6 @@ val parse_flags : string -> Flags.t Or_error.t
 val parse_rname : string -> string option Or_error.t
 val parse_pos : string -> int option Or_error.t
 val parse_mapq : string -> int option Or_error.t
-val parse_cigar : string -> cigar_op list Or_error.t
 val parse_rnext : string -> rnext option Or_error.t
 val parse_pnext : string -> int option Or_error.t
 val parse_tlen : string -> int option Or_error.t
@@ -391,8 +396,6 @@ val print_flags : Flags.t -> string
 val print_rname : string option -> string
 val print_pos : int option -> string
 val print_mapq : int option -> string
-val print_cigar_op : cigar_op -> string
-val print_cigar : cigar_op list -> string
 val print_rnext : rnext option -> string
 val print_pnext : int option -> string
 val print_tlen : int option -> string

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -237,7 +237,8 @@ module Header : sig
     -> unit
     -> t Or_error.t
 
-  val add : t -> Item.t -> t Or_error.t
+  (** [of_item_list_rev items] takes a list of header items in reverse order. *)
+  val of_item_list_rev : Item.t list -> t Or_error.t
 end
 
 module Qname : sig
@@ -444,51 +445,13 @@ module Alignment : sig
   val string_of_t : t -> string
 end
 
-module Line : sig
-  (** Minimal parsing of a line. This module determines if a line starts
-      with an ['@'] character or not. If it does, the line is marked as
-      a [`Header] line, and otherwise it is marked as an [`Alignment] line.
-
-      The [parse] function returns the expected type of the next line. Thus,
-      you can easily call it iteratively over a stream of lines, being assured
-      to get an error if they are not in the correct order. *)
-
-  module Error : sig
-    type t =
-      [ `Invalid_header
-      | `Invalid_alignment
-      | `Empty
-      ]
-    [@@deriving sexp]
-  end
-
-  module Type : sig
-    type t =
-      [ `Header
-      | `Alignment
-      | `Header_or_alignment
-      ]
-    [@@deriving sexp]
-  end
-
+module State : sig
   type t =
-    [ `Header of string
-    | `Alignment of string
+    [ `Header of Header.Item.t list
+    | `Alignment of Header.t * Alignment.t
     ]
   [@@deriving sexp]
 
-  (** [parse ~type_ line] parses [line] of type [type_]. Returns the parsed line
-      and the expected type of the next line. *)
-  val parse : type_:Type.t -> string -> (t * Type.t, Error.t) Result.t
-end
-
-module State : sig
-  type t =
-    { header : Header.t
-    ; next : Line.Type.t
-    }
-  [@@deriving sexp]
-
   val init : t
-  val reduce : t -> string -> (t * Alignment.t option, Base.Error.t) Result.t
+  val reduce : t -> string -> t Or_error.t
 end

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -251,10 +251,7 @@ module Header : sig
   (** [of_item_list_rev items] takes a list of header items in reverse order. *)
   val of_item_list_rev : Item_list_rev.t -> t Or_error.t
 
-  (** [num_items t] is the number of header lines that [t] logically
-      consists of, i.e. the number of header lines that it was derived
-      from or that it would print to. *)
-  val num_items : t -> int
+  val to_items : t -> Item.t list
 end
 
 module Qname : sig

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -31,51 +31,51 @@ module Header : sig
     val print : t -> string
   end
 
-  module Sort_order : sig
-    type t =
-      [ `Unknown
-      | `Unsorted
-      | `Query_name
-      | `Coordinate
-      ]
-    [@@deriving sexp]
-
-    val parse : string -> t Or_error.t
-    val print : t -> string
-  end
-
-  module Group_order : sig
-    type t =
-      [ `None
-      | `Query
-      | `Reference
-      ]
-    [@@deriving sexp]
-
-    val parse : string -> t Or_error.t
-    val print : t -> string
-  end
-
-  val parse_header_version : string -> string Or_error.t
-  val print_header_version : string -> string
-
   module HD : sig
+    module SO : sig
+      type t =
+        [ `Unknown
+        | `Unsorted
+        | `Query_name
+        | `Coordinate
+        ]
+      [@@deriving sexp]
+
+      val parse : string -> t Or_error.t
+      val print : t -> string
+    end
+
+    module GO : sig
+      type t =
+        [ `None
+        | `Query
+        | `Reference
+        ]
+      [@@deriving sexp]
+
+      val parse : string -> t Or_error.t
+      val print : t -> string
+    end
+
+    val parse_header_version : string -> string Or_error.t
+    val print_header_version : string -> string
+
     (** @HD. A header consists of different types of lines. Confusingly, one of
       these types is called {i the} "header line", which is what this
       type refers to. It does not refer generically to any line within a
       header. *)
     type t =
       { version : string (** VN *)
-      ; sort_order : Sort_order.t option (** SO *)
-      ; group_order : Group_order.t option (** GO *)
+      ; sort_order : SO.t option (** SO *)
+      ; group_order : GO.t option (** GO *)
       }
     [@@deriving sexp]
     (* FIXME: Make the type private. Removed temporarily to fix build. *)
 
     val header_line
       :  version:string
-      -> ?sort_order:Sort_order.t
-      -> ?group_order:Group_order.t
+      -> ?sort_order:SO.t
+      -> ?group_order:GO.t
       -> unit
       -> t Or_error.t
 
@@ -214,8 +214,8 @@ module Header : sig
   *)
   type t =
     { version : string option
-    ; sort_order : Sort_order.t option
-    ; group_order : Group_order.t option
+    ; sort_order : HD.SO.t option
+    ; group_order : HD.GO.t option
     ; ref_seqs : SQ.t list
     ; read_groups : RG.t list
     ; programs : PG.t list
@@ -228,8 +228,8 @@ module Header : sig
 
   val header
     :  ?version:string
-    -> ?sort_order:Sort_order.t
-    -> ?group_order:Group_order.t
+    -> ?sort_order:HD.SO.t
+    -> ?group_order:HD.GO.t
     -> ?ref_seqs:SQ.t list
     -> ?read_groups:RG.t list
     -> ?programs:PG.t list

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -16,7 +16,7 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val string_of_t : t -> string
+    val to_string : t -> string
   end
 
   module Tag_value : sig
@@ -25,7 +25,7 @@ module Header : sig
       those in the header. *)
     type t = private string * string [@@deriving sexp]
 
-    val string_of_t : t -> string
+    val to_string : t -> string
   end
 
   module HD : sig
@@ -38,8 +38,8 @@ module Header : sig
         ]
       [@@deriving sexp]
 
-      val t_of_string : string -> t Or_error.t
-      val string_of_t : t -> string
+      val of_string : string -> t Or_error.t
+      val to_string : t -> string
     end
 
     module GO : sig
@@ -50,15 +50,15 @@ module Header : sig
         ]
       [@@deriving sexp]
 
-      val t_of_string : string -> t Or_error.t
-      val string_of_t : t -> string
+      val of_string : string -> t Or_error.t
+      val to_string : t -> string
     end
 
     module VN : sig
       type t = string [@@deriving sexp]
 
-      val t_of_string : string -> t Or_error.t
-      val string_of_t : t -> string
+      val of_string : string -> t Or_error.t
+      val to_string : t -> string
     end
 
     type t =
@@ -77,7 +77,7 @@ module Header : sig
       -> t Or_error.t
 
     val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
-    val string_of_t : t -> string
+    val to_string : t -> string
   end
 
   module SQ : sig
@@ -102,7 +102,7 @@ module Header : sig
       -> t Or_error.t
 
     val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
-    val string_of_t : t -> string
+    val to_string : t -> string
   end
 
   module RG : sig
@@ -118,8 +118,8 @@ module Header : sig
         ]
       [@@deriving sexp]
 
-      val t_of_string : string -> t Or_error.t
-      val string_of_t : t -> string
+      val of_string : string -> t Or_error.t
+      val to_string : t -> string
     end
 
     type t = private
@@ -158,7 +158,7 @@ module Header : sig
       -> t Or_error.t
 
     val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
-    val string_of_t : t -> string
+    val to_string : t -> string
   end
 
   module PG : sig
@@ -173,13 +173,13 @@ module Header : sig
     [@@deriving sexp]
 
     val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
-    val string_of_t : t -> string
+    val to_string : t -> string
   end
 
   module Other : sig
     type t = string * Tag_value.t list [@@deriving sexp]
 
-    val string_of_t : t -> string
+    val to_string : t -> string
   end
 
   module Item : sig
@@ -194,7 +194,7 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val t_of_string : string -> t Or_error.t
+    val of_string : string -> t Or_error.t
   end
 
   module Item_list_rev : sig
@@ -261,7 +261,7 @@ module Qname : sig
   type t = string [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Flag : sig
@@ -270,8 +270,8 @@ module Flag : sig
   type t = private int [@@deriving sexp]
 
   val of_int : int -> t Or_error.t
-  val t_of_string : string -> t Or_error.t
-  val string_of_t : t -> string
+  val of_string : string -> t Or_error.t
+  val to_string : t -> string
   val has_multiple_segments : t -> bool
   val each_segment_properly_aligned : t -> bool
   val segment_unmapped : t -> bool
@@ -290,21 +290,21 @@ module Rname : sig
   type t = string [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Pos : sig
   type t = int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Mapq : sig
   type t = int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Cigar : sig
@@ -324,7 +324,7 @@ module Cigar : sig
       ]
     [@@deriving sexp]
 
-    val string_of_t : t -> string
+    val to_string : t -> string
     val alignment_match_of_int : int -> t Or_error.t
     val insertion_of_int : int -> t Or_error.t
     val deletion_of_int : int -> t Or_error.t
@@ -338,8 +338,8 @@ module Cigar : sig
 
   type t = Op.t list [@@deriving sexp]
 
-  val t_of_string : string -> t Or_error.t
-  val string_of_t : t -> string
+  val of_string : string -> t Or_error.t
+  val to_string : t -> string
 end
 
 module Rnext : sig
@@ -351,35 +351,35 @@ module Rnext : sig
   [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Pnext : sig
   type t = int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Tlen : sig
   type t = int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Seq : sig
   type t = string [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
-  val string_of_t_option : t option -> string
+  val to_string_option : t option -> string
 end
 
 module Qual : sig
   type t = Phred_score.t list [@@deriving sexp]
 
-  val t_of_string : string -> t Or_error.t
-  val string_of_t : t -> string
+  val of_string : string -> t Or_error.t
+  val to_string : t -> string
 end
 
 module Optional_field : sig
@@ -400,10 +400,10 @@ module Optional_field : sig
     val t_of_char_A : char -> t Or_error.t
     val t_of_int64_i : Int64.t -> t
     val t_of_float_f : float -> t
-    val t_of_string_Z : string -> t Or_error.t
-    val t_of_string_H : string -> t Or_error.t
+    val of_string_Z : string -> t Or_error.t
+    val of_string_H : string -> t Or_error.t
     val t_of_char_string_list_B : char -> string list -> t Or_error.t
-    val t_of_string : string -> t Or_error.t
+    val of_string : string -> t Or_error.t
   end
 
   type t = private
@@ -413,8 +413,8 @@ module Optional_field : sig
   [@@deriving sexp]
 
   val make : string -> Value.t -> t Or_error.t
-  val t_of_string : string -> t Or_error.t
-  val string_of_t : t -> string
+  val of_string : string -> t Or_error.t
+  val to_string : t -> string
 end
 
 module Alignment : sig
@@ -453,12 +453,12 @@ module Alignment : sig
     -> unit
     -> t Or_error.t
 
-  val t_of_string
+  val of_string
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> string
     -> t Or_error.t
 
-  val string_of_t : t -> string
+  val to_string : t -> string
 end
 
 module Parser : sig

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -195,6 +195,7 @@ module Header : sig
     [@@deriving sexp]
 
     val of_string : string -> t Or_error.t
+    val to_string : t -> string
   end
 
   module Item_list_rev : sig
@@ -222,9 +223,7 @@ module Header : sig
      - [comments]: Unordered list of @CO lines.
   *)
   type t =
-    { version : HD.VN.t option
-    ; sort_order : HD.SO.t option
-    ; group_order : HD.GO.t option
+    { hd : HD.t option
     ; ref_seqs : SQ.t list
     ; read_groups : RG.t list
     ; programs : PG.t list
@@ -237,9 +236,7 @@ module Header : sig
   val empty : t
 
   val make
-    :  ?version:string
-    -> ?sort_order:HD.SO.t
-    -> ?group_order:HD.GO.t
+    :  ?hd:HD.t
     -> ?ref_seqs:SQ.t list
     -> ?read_groups:RG.t list
     -> ?programs:PG.t list

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -198,17 +198,6 @@ module Header : sig
     val to_string : t -> string
   end
 
-  module Item_list_rev : sig
-    (** Header lines stored in a list with items in reverse order. *)
-    type t = private Item.t list [@@deriving sexp]
-
-    val empty : t
-
-    (** [append t x] appends [x] to [t]. It is logically the last item,
-        but stored as the first item in the list underlying [t]. *)
-    val append : t -> Item.t -> t
-  end
-
   (**
      - [sort_order]: Guaranteed to be [None] if [version = None].
 
@@ -246,7 +235,7 @@ module Header : sig
     -> t Or_error.t
 
   (** [of_item_list_rev items] takes a list of header items in reverse order. *)
-  val of_item_list_rev : Item_list_rev.t -> t Or_error.t
+  val of_item_list_rev : Item.t list -> t Or_error.t
 
   (** [of_lines lines] parses [lines] through all header lines. Returns the
       header and any remaining lines, which are presumably alignment lines. *)
@@ -464,7 +453,7 @@ module Parser : sig
 
   module State : sig
     type t =
-      [ `Header of Header.Item_list_rev.t
+      [ `Header of Header.Item.t list (* items in reverse order *)
       | `Alignment of Header.t * Alignment.t
       ]
   end

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -291,43 +291,6 @@ module Cigar_op : sig
   val cigar_op_seq_mismatch : int -> t Or_error.t
 end
 
-module Optional_field_value : sig
-  (** The constructor encodes the TYPE and each carries its
-    corresponding VALUE. *)
-  type t =
-    private
-    [< `A of char
-    | `i of Int64.t
-    | `f of float
-    | `Z of string
-    | `H of string
-    | `B of char * string list
-    ]
-  [@@deriving sexp]
-
-  (** {3 Low-level Optional field Parsers and Constructors} *)
-
-  val optional_field_value_A : char -> t Or_error.t
-  val optional_field_value_i : Int64.t -> t
-  val optional_field_value_f : float -> t
-  val optional_field_value_Z : string -> t Or_error.t
-  val optional_field_value_H : string -> t Or_error.t
-  val optional_field_value_B : char -> string list -> t Or_error.t
-  val parse : string -> t Or_error.t
-end
-
-module Optional_field : sig
-  type t = private
-    { tag : string
-    ; value : Optional_field_value.t
-    }
-  [@@deriving sexp]
-
-  val make : string -> Optional_field_value.t -> t Or_error.t
-  val parse : string -> t Or_error.t
-  val print : t -> string
-end
-
 module Rnext : sig
   type t =
     private
@@ -338,6 +301,41 @@ module Rnext : sig
 
   val parse : string -> t option Or_error.t
   val print : t option -> string
+end
+
+module Optional_field : sig
+  module Value : sig
+    (** The constructor encodes the TYPE and each carries its
+      corresponding VALUE. *)
+    type t =
+      private
+      [< `A of char
+      | `i of Int64.t
+      | `f of float
+      | `Z of string
+      | `H of string
+      | `B of char * string list
+      ]
+    [@@deriving sexp]
+
+    val parse_A : char -> t Or_error.t
+    val parse_i : Int64.t -> t
+    val parse_f : float -> t
+    val parse_Z : string -> t Or_error.t
+    val parse_H : string -> t Or_error.t
+    val parse_B : char -> string list -> t Or_error.t
+    val parse : string -> t Or_error.t
+  end
+
+  type t = private
+    { tag : string
+    ; value : Value.t
+    }
+  [@@deriving sexp]
+
+  val make : string -> Value.t -> t Or_error.t
+  val parse : string -> t Or_error.t
+  val print : t -> string
 end
 
 module Alignment : sig

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -76,7 +76,7 @@ module Header : sig
     [@@deriving sexp]
     (* FIXME: Make the type private. Removed temporarily to fix build. *)
 
-    val header_line
+    val make
       :  version:string
       -> ?sort_order:SO.t
       -> ?group_order:GO.t
@@ -99,7 +99,7 @@ module Header : sig
       }
     [@@deriving sexp]
 
-    val ref_seq
+    val make
       :  name:string
       -> length:int
       -> ?assembly:string
@@ -150,7 +150,7 @@ module Header : sig
     (** The [run_date] string will be parsed as a Date.t or Time.t,
     whichever is possible. If it is a time without a timezone, local
     timezone will be assumed. *)
-    val read_group
+    val make
       :  id:string
       -> ?seq_center:string
       -> ?description:string
@@ -230,7 +230,7 @@ module Header : sig
 
   val empty_header : t
 
-  val header
+  val make
     :  ?version:string
     -> ?sort_order:HD.SO.t
     -> ?group_order:HD.GO.t
@@ -327,7 +327,7 @@ module Optional_field : sig
     }
   [@@deriving sexp]
 
-  val optional_field : string -> Optional_field_value.t -> t Or_error.t
+  val make : string -> Optional_field_value.t -> t Or_error.t
   val parse : string -> t Or_error.t
   val print : t -> string
 end
@@ -363,7 +363,7 @@ module Alignment : sig
     }
   [@@deriving sexp]
 
-  val alignment
+  val make
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> ?qname:string
     -> flags:Flags.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -222,7 +222,7 @@ module Header : sig
     }
   (* FIXME: Make the type private. Removed temporarily to fix build. *)
 
-  val empty_header : t
+  val empty : t
 
   val make
     :  ?version:string

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -464,7 +464,7 @@ end
 module Parser : sig
   (** State-machine based parser. *)
 
-  module Phase : sig
+  module State : sig
     type t =
       [ `Header of Header.Item_list_rev.t
       | `Alignment of Header.t * Alignment.t
@@ -481,7 +481,7 @@ module Parser : sig
   val header : _ t -> Header.t Or_error.t
 
   val header_exn : _ t -> Header.t
-  val phase : _ t -> Phase.t
+  val state : _ t -> State.t
   val data : 'a t -> 'a
 end
 

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -463,10 +463,9 @@ end
 
 module State : sig
   type t =
-    [ `Header of Header.Item_list_rev.t
-    | `Alignment of Header.t * Alignment.t
-    ]
-  [@@deriving sexp]
+    { parse_line : string -> t Or_error.t
+    ; data : [ `Header of Header.Item_list_rev.t | `Alignment of Header.t * Alignment.t ]
+    }
 
   val init : t
   val reduce : t -> string -> t Or_error.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -19,7 +19,7 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val print_header_item_tag : t -> string
+    val print : t -> string
   end
 
   module Tag_value : sig
@@ -28,7 +28,7 @@ module Header : sig
       those in the header. *)
     type t = private string * string [@@deriving sexp]
 
-    val print_tag_value : t -> string
+    val print : t -> string
   end
 
   module Sort_order : sig
@@ -40,8 +40,8 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val parse_sort_order : string -> t Or_error.t
-    val print_sort_order : t -> string
+    val parse : string -> t Or_error.t
+    val print : t -> string
   end
 
   module Group_order : sig
@@ -51,6 +51,9 @@ module Header : sig
       | `Reference
       ]
     [@@deriving sexp]
+
+    val parse : string -> t Or_error.t
+    val print : t -> string
   end
 
   val parse_header_version : string -> string Or_error.t
@@ -76,8 +79,8 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val parse_header_line : Tag_value.t list -> t Or_error.t
-    val print_header_line : t -> string
+    val parse : Tag_value.t list -> t Or_error.t
+    val print : t -> string
   end
 
   module Ref_seq : sig
@@ -102,8 +105,8 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val parse_ref_seq : Tag_value.t list -> t Or_error.t
-    val print_ref_seq : t -> string
+    val parse : Tag_value.t list -> t Or_error.t
+    val print : t -> string
   end
 
   module Platform : sig
@@ -118,8 +121,8 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val parse_platform : string -> t Or_error.t
-    val print_platform : t -> string
+    val parse : string -> t Or_error.t
+    val print : t -> string
   end
 
   module Read_group : sig
@@ -159,8 +162,8 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val parse_read_group : Tag_value.t list -> t Or_error.t
-    val print_read_group : t -> string
+    val parse : Tag_value.t list -> t Or_error.t
+    val print : t -> string
   end
 
   module Program : sig
@@ -175,8 +178,8 @@ module Header : sig
       }
     [@@deriving sexp]
 
-    val parse_program : Tag_value.t list -> t Or_error.t
-    val print_program : t -> string
+    val parse : Tag_value.t list -> t Or_error.t
+    val print : t -> string
   end
 
   module Header_item : sig
@@ -191,7 +194,7 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val parse_header_item : Line.t -> t Or_error.t
+    val parse : Line.t -> t Or_error.t
   end
 
   val print_other : string * Tag_value.t list -> string
@@ -272,7 +275,7 @@ module Cigar_op : sig
   [@@deriving sexp]
 
   val parse_cigar : string -> t list Or_error.t
-  val print_cigar_op : t -> string
+  val print : t -> string
   val print_cigar : t list -> string
 
   (** {3 Low-level Optional field Parsers and Constructors} *)
@@ -310,7 +313,7 @@ module Optional_field_value : sig
   val optional_field_value_Z : string -> t Or_error.t
   val optional_field_value_H : string -> t Or_error.t
   val optional_field_value_B : char -> string list -> t Or_error.t
-  val parse_optional_field_value : string -> t Or_error.t
+  val parse : string -> t Or_error.t
 end
 
 module Optional_field : sig
@@ -321,8 +324,8 @@ module Optional_field : sig
   [@@deriving sexp]
 
   val optional_field : string -> Optional_field_value.t -> t Or_error.t
-  val parse_optional_field : string -> t Or_error.t
-  val print_optional_field : t -> string
+  val parse : string -> t Or_error.t
+  val print : t -> string
 end
 
 module Rnext : sig
@@ -333,8 +336,8 @@ module Rnext : sig
     ]
   [@@deriving sexp]
 
-  val parse_rnext : string -> t option Or_error.t
-  val print_rnext : t option -> string
+  val parse : string -> t option Or_error.t
+  val print : t option -> string
 end
 
 module Alignment : sig
@@ -383,7 +386,7 @@ module Alignment : sig
   val parse_seq : string -> string option Or_error.t
   val parse_qual : string -> Phred_score.t list Or_error.t
 
-  val parse_alignment
+  val parse
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> Line.t
     -> t Or_error.t
@@ -397,5 +400,5 @@ module Alignment : sig
   val print_tlen : int option -> string
   val print_seq : string option -> string
   val print_qual : Phred_score.t list -> string
-  val print_alignment : t -> string
+  val print : t -> string
 end

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -343,71 +343,65 @@ module Rnext : sig
   val print_rnext : t option -> string
 end
 
-(** For [cigar] and [qual], empty list indicates no value, i.e. '*',
+module Alignment : sig
+  (** For [cigar] and [qual], empty list indicates no value, i.e. '*',
     was given. *)
-type alignment = private
-  { qname : string option (** QNAME *)
-  ; flags : Flags.t (** FLAG *)
-  ; rname : string option (** RNAME *)
-  ; pos : int option (** POS *)
-  ; mapq : int option (** MAPQ *)
-  ; cigar : Cigar_op.t list (** CIGAR *)
-  ; rnext : Rnext.t option (** RNEXT *)
-  ; pnext : int option (** PNEXT *)
-  ; tlen : int option (** TLEN *)
-  ; seq : string option (** SEQ *)
-  ; qual : Phred_score.t list (** QUAL *)
-  ; optional_fields : Optional_field.t list
-  }
-[@@deriving sexp]
+  type t = private
+    { qname : string option (** QNAME *)
+    ; flags : Flags.t (** FLAG *)
+    ; rname : string option (** RNAME *)
+    ; pos : int option (** POS *)
+    ; mapq : int option (** MAPQ *)
+    ; cigar : Cigar_op.t list (** CIGAR *)
+    ; rnext : Rnext.t option (** RNEXT *)
+    ; pnext : int option (** PNEXT *)
+    ; tlen : int option (** TLEN *)
+    ; seq : string option (** SEQ *)
+    ; qual : Phred_score.t list (** QUAL *)
+    ; optional_fields : Optional_field.t list
+    }
+  [@@deriving sexp]
 
-(** {2 Low-level Parsers and Constructors} *)
+  val alignment
+    :  ?ref_seqs:(string, String.comparator_witness) Set.t
+    -> ?qname:string
+    -> flags:Flags.t
+    -> ?rname:string
+    -> ?pos:int
+    -> ?mapq:int
+    -> ?cigar:Cigar_op.t list
+    -> ?rnext:Rnext.t
+    -> ?pnext:int
+    -> ?tlen:int
+    -> ?seq:string
+    -> ?qual:Phred_score.t list
+    -> ?optional_fields:Optional_field.t list
+    -> unit
+    -> t Or_error.t
 
-(** {3 Low-level Alignment Parsers and Constructors} *)
+  val parse_qname : string -> string option Or_error.t
+  val parse_flags : string -> Flags.t Or_error.t
+  val parse_rname : string -> string option Or_error.t
+  val parse_pos : string -> int option Or_error.t
+  val parse_mapq : string -> int option Or_error.t
+  val parse_pnext : string -> int option Or_error.t
+  val parse_tlen : string -> int option Or_error.t
+  val parse_seq : string -> string option Or_error.t
+  val parse_qual : string -> Phred_score.t list Or_error.t
 
-val alignment
-  :  ?ref_seqs:(string, String.comparator_witness) Set.t
-  -> ?qname:string
-  -> flags:Flags.t
-  -> ?rname:string
-  -> ?pos:int
-  -> ?mapq:int
-  -> ?cigar:Cigar_op.t list
-  -> ?rnext:Rnext.t
-  -> ?pnext:int
-  -> ?tlen:int
-  -> ?seq:string
-  -> ?qual:Phred_score.t list
-  -> ?optional_fields:Optional_field.t list
-  -> unit
-  -> alignment Or_error.t
+  val parse_alignment
+    :  ?ref_seqs:(string, String.comparator_witness) Set.t
+    -> Line.t
+    -> t Or_error.t
 
-val parse_qname : string -> string option Or_error.t
-val parse_flags : string -> Flags.t Or_error.t
-val parse_rname : string -> string option Or_error.t
-val parse_pos : string -> int option Or_error.t
-val parse_mapq : string -> int option Or_error.t
-val parse_pnext : string -> int option Or_error.t
-val parse_tlen : string -> int option Or_error.t
-val parse_seq : string -> string option Or_error.t
-val parse_qual : string -> Phred_score.t list Or_error.t
-
-val parse_alignment
-  :  ?ref_seqs:(string, String.comparator_witness) Set.t
-  -> Line.t
-  -> alignment Or_error.t
-
-(** {2 Low-level Printers} *)
-
-(** {3 Low-level Alignment Printers} *)
-
-val print_qname : string option -> string
-val print_flags : Flags.t -> string
-val print_rname : string option -> string
-val print_pos : int option -> string
-val print_mapq : int option -> string
-val print_pnext : int option -> string
-val print_tlen : int option -> string
-val print_seq : string option -> string
-val print_qual : Phred_score.t list -> string
-val print_alignment : alignment -> string
+  val print_qname : string option -> string
+  val print_flags : Flags.t -> string
+  val print_rname : string option -> string
+  val print_pos : int option -> string
+  val print_mapq : int option -> string
+  val print_pnext : int option -> string
+  val print_tlen : int option -> string
+  val print_seq : string option -> string
+  val print_qual : Phred_score.t list -> string
+  val print_alignment : t -> string
+end

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -16,7 +16,7 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val print : t -> string
+    val string_of_t : t -> string
   end
 
   module Tag_value : sig
@@ -25,7 +25,7 @@ module Header : sig
       those in the header. *)
     type t = private string * string [@@deriving sexp]
 
-    val print : t -> string
+    val string_of_t : t -> string
   end
 
   module HD : sig
@@ -38,8 +38,8 @@ module Header : sig
         ]
       [@@deriving sexp]
 
-      val parse : string -> t Or_error.t
-      val print : t -> string
+      val t_of_string : string -> t Or_error.t
+      val string_of_t : t -> string
     end
 
     module GO : sig
@@ -50,15 +50,15 @@ module Header : sig
         ]
       [@@deriving sexp]
 
-      val parse : string -> t Or_error.t
-      val print : t -> string
+      val t_of_string : string -> t Or_error.t
+      val string_of_t : t -> string
     end
 
     module VN : sig
       type t = string [@@deriving sexp]
 
-      val parse : string -> string Or_error.t
-      val print : string -> string
+      val t_of_string : string -> t Or_error.t
+      val string_of_t : t -> string
     end
 
     type t =
@@ -76,8 +76,8 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val parse : Tag_value.t list -> t Or_error.t
-    val print : t -> string
+    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val string_of_t : t -> string
   end
 
   module SQ : sig
@@ -101,8 +101,8 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val parse : Tag_value.t list -> t Or_error.t
-    val print : t -> string
+    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val string_of_t : t -> string
   end
 
   module RG : sig
@@ -118,8 +118,8 @@ module Header : sig
         ]
       [@@deriving sexp]
 
-      val parse : string -> t Or_error.t
-      val print : t -> string
+      val t_of_string : string -> t Or_error.t
+      val string_of_t : t -> string
     end
 
     type t = private
@@ -157,8 +157,8 @@ module Header : sig
       -> unit
       -> t Or_error.t
 
-    val parse : Tag_value.t list -> t Or_error.t
-    val print : t -> string
+    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val string_of_t : t -> string
   end
 
   module PG : sig
@@ -172,14 +172,14 @@ module Header : sig
       }
     [@@deriving sexp]
 
-    val parse : Tag_value.t list -> t Or_error.t
-    val print : t -> string
+    val t_of_tag_value_list : Tag_value.t list -> t Or_error.t
+    val string_of_t : t -> string
   end
 
   module Other : sig
     type t = string * Tag_value.t list [@@deriving sexp]
 
-    val print : t -> string
+    val string_of_t : t -> string
   end
 
   module Item : sig
@@ -194,7 +194,7 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val parse : Line.t -> t Or_error.t
+    val t_of_line : Line.t -> t Or_error.t
   end
 
   (**
@@ -240,8 +240,8 @@ end
 module Qname : sig
   type t = string [@@deriving sexp]
 
-  val parse : string -> t option Or_error.t
-  val print : t option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Flag : sig
@@ -250,8 +250,8 @@ module Flag : sig
   type t = private int [@@deriving sexp]
 
   val of_int : int -> t Or_error.t
-  val parse : string -> t Or_error.t
-  val print : t -> string
+  val t_of_string : string -> t Or_error.t
+  val string_of_t : t -> string
   val has_multiple_segments : t -> bool
   val each_segment_properly_aligned : t -> bool
   val segment_unmapped : t -> bool
@@ -269,22 +269,22 @@ end
 module Rname : sig
   type t = string [@@deriving sexp]
 
-  val parse : string -> string option Or_error.t
-  val print : string option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Pos : sig
   type t = int [@@deriving sexp]
 
-  val parse : string -> int option Or_error.t
-  val print : int option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Mapq : sig
   type t = int [@@deriving sexp]
 
-  val parse : string -> int option Or_error.t
-  val print : int option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Cigar : sig
@@ -304,7 +304,7 @@ module Cigar : sig
       ]
     [@@deriving sexp]
 
-    val print : t -> string
+    val string_of_t : t -> string
     val alignment_match_of_int : int -> t Or_error.t
     val insertion_of_int : int -> t Or_error.t
     val deletion_of_int : int -> t Or_error.t
@@ -318,8 +318,8 @@ module Cigar : sig
 
   type t = Op.t list [@@deriving sexp]
 
-  val parse : string -> t Or_error.t
-  val print : t -> string
+  val t_of_string : string -> t Or_error.t
+  val string_of_t : t -> string
 end
 
 module Rnext : sig
@@ -330,36 +330,36 @@ module Rnext : sig
     ]
   [@@deriving sexp]
 
-  val parse : string -> t option Or_error.t
-  val print : t option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Pnext : sig
   type t = int [@@deriving sexp]
 
-  val parse : string -> int option Or_error.t
-  val print : int option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Tlen : sig
   type t = int [@@deriving sexp]
 
-  val parse : string -> int option Or_error.t
-  val print : int option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Seq : sig
   type t = string [@@deriving sexp]
 
-  val parse : string -> string option Or_error.t
-  val print : string option -> string
+  val t_option_of_string : string -> t option Or_error.t
+  val string_of_t_option : t option -> string
 end
 
 module Qual : sig
   type t = Phred_score.t list [@@deriving sexp]
 
-  val parse : string -> Phred_score.t list Or_error.t
-  val print : Phred_score.t list -> string
+  val t_of_string : string -> t Or_error.t
+  val string_of_t : t -> string
 end
 
 module Optional_field : sig
@@ -377,13 +377,13 @@ module Optional_field : sig
       ]
     [@@deriving sexp]
 
-    val parse_A : char -> t Or_error.t
-    val parse_i : Int64.t -> t
-    val parse_f : float -> t
-    val parse_Z : string -> t Or_error.t
-    val parse_H : string -> t Or_error.t
-    val parse_B : char -> string list -> t Or_error.t
-    val parse : string -> t Or_error.t
+    val t_of_char_A : char -> t Or_error.t
+    val t_of_int64_i : Int64.t -> t
+    val t_of_float_f : float -> t
+    val t_of_string_Z : string -> t Or_error.t
+    val t_of_string_H : string -> t Or_error.t
+    val t_of_char_string_list_B : char -> string list -> t Or_error.t
+    val t_of_string : string -> t Or_error.t
   end
 
   type t = private
@@ -393,8 +393,8 @@ module Optional_field : sig
   [@@deriving sexp]
 
   val make : string -> Value.t -> t Or_error.t
-  val parse : string -> t Or_error.t
-  val print : t -> string
+  val t_of_string : string -> t Or_error.t
+  val string_of_t : t -> string
 end
 
 module Alignment : sig
@@ -433,10 +433,10 @@ module Alignment : sig
     -> unit
     -> t Or_error.t
 
-  val parse
+  val t_of_line
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> Line.t
     -> t Or_error.t
 
-  val print : t -> string
+  val string_of_t : t -> string
 end

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -176,7 +176,7 @@ module Header : sig
     val print : t -> string
   end
 
-  module Header_item : sig
+  module Item : sig
     type t =
       private
       [< `HD of HD.t

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -250,21 +250,21 @@ module Flag : sig
 end
 
 module Rname : sig
-  type t = string [@@deriving sexp]
+  type t = private string [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
   val to_string_option : t option -> string
 end
 
 module Pos : sig
-  type t = int [@@deriving sexp]
+  type t = private int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
   val to_string_option : t option -> string
 end
 
 module Mapq : sig
-  type t = int [@@deriving sexp]
+  type t = private int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
   val to_string_option : t option -> string
@@ -272,7 +272,6 @@ end
 
 module Cigar : sig
   module Op : sig
-    (** CIGAR operations. *)
     type t =
       private
       [< `Alignment_match of int
@@ -318,21 +317,21 @@ module Rnext : sig
 end
 
 module Pnext : sig
-  type t = int [@@deriving sexp]
+  type t = private int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
   val to_string_option : t option -> string
 end
 
 module Tlen : sig
-  type t = int [@@deriving sexp]
+  type t = private int [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
   val to_string_option : t option -> string
 end
 
 module Seq : sig
-  type t = string [@@deriving sexp]
+  type t = private string [@@deriving sexp]
 
   val t_option_of_string : string -> t option Or_error.t
   val to_string_option : t option -> string

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -258,37 +258,39 @@ module Flags : sig
   val supplementary_alignment : t -> bool
 end
 
-module Cigar_op : sig
-  (** CIGAR operations. *)
-  type t =
-    private
-    [< `Alignment_match of int
-    | `Insertion of int
-    | `Deletion of int
-    | `Skipped of int
-    | `Soft_clipping of int
-    | `Hard_clipping of int
-    | `Padding of int
-    | `Seq_match of int
-    | `Seq_mismatch of int
-    ]
-  [@@deriving sexp]
+module Cigar : sig
+  module Op : sig
+    (** CIGAR operations. *)
+    type t =
+      private
+      [< `Alignment_match of int
+      | `Insertion of int
+      | `Deletion of int
+      | `Skipped of int
+      | `Soft_clipping of int
+      | `Hard_clipping of int
+      | `Padding of int
+      | `Seq_match of int
+      | `Seq_mismatch of int
+      ]
+    [@@deriving sexp]
 
-  val parse_cigar : string -> t list Or_error.t
+    val print : t -> string
+    val alignment_match_of_int : int -> t Or_error.t
+    val insertion_of_int : int -> t Or_error.t
+    val deletion_of_int : int -> t Or_error.t
+    val skipped_of_int : int -> t Or_error.t
+    val soft_clipping_of_int : int -> t Or_error.t
+    val hard_clipping_of_int : int -> t Or_error.t
+    val padding_of_int : int -> t Or_error.t
+    val seq_match_of_int : int -> t Or_error.t
+    val seq_mismatch_of_int : int -> t Or_error.t
+  end
+
+  type t = Op.t list [@@deriving sexp]
+
+  val parse : string -> t Or_error.t
   val print : t -> string
-  val print_cigar : t list -> string
-
-  (** {3 Low-level Optional field Parsers and Constructors} *)
-
-  val cigar_op_alignment_match : int -> t Or_error.t
-  val cigar_op_insertion : int -> t Or_error.t
-  val cigar_op_deletion : int -> t Or_error.t
-  val cigar_op_skipped : int -> t Or_error.t
-  val cigar_op_soft_clipping : int -> t Or_error.t
-  val cigar_op_hard_clipping : int -> t Or_error.t
-  val cigar_op_padding : int -> t Or_error.t
-  val cigar_op_seq_match : int -> t Or_error.t
-  val cigar_op_seq_mismatch : int -> t Or_error.t
 end
 
 module Rnext : sig
@@ -347,7 +349,7 @@ module Alignment : sig
     ; rname : string option (** RNAME *)
     ; pos : int option (** POS *)
     ; mapq : int option (** MAPQ *)
-    ; cigar : Cigar_op.t list (** CIGAR *)
+    ; cigar : Cigar.t (** CIGAR *)
     ; rnext : Rnext.t option (** RNEXT *)
     ; pnext : int option (** PNEXT *)
     ; tlen : int option (** TLEN *)
@@ -364,7 +366,7 @@ module Alignment : sig
     -> ?rname:string
     -> ?pos:int
     -> ?mapq:int
-    -> ?cigar:Cigar_op.t list
+    -> ?cigar:Cigar.t
     -> ?rnext:Rnext.t
     -> ?pnext:int
     -> ?tlen:int

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -244,8 +244,9 @@ module Qname : sig
   val print : t option -> string
 end
 
-module Flags : sig
-  (** Flags are represented as a "bit map". *)
+module Flag : sig
+  (** The FLAG field represents a "bit map" of flags (plural). We use the
+      singular form for consistency with the SAM specification. *)
   type t = private int [@@deriving sexp]
 
   val of_int : int -> t Or_error.t
@@ -401,7 +402,7 @@ module Alignment : sig
     was given. *)
   type t = private
     { qname : Qname.t option (** QNAME *)
-    ; flags : Flags.t (** FLAG *)
+    ; flag : Flag.t (** FLAG *)
     ; rname : Rname.t option (** RNAME *)
     ; pos : Pos.t option (** POS *)
     ; mapq : int option (** MAPQ *)
@@ -418,7 +419,7 @@ module Alignment : sig
   val make
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> ?qname:Qname.t
-    -> flags:Flags.t
+    -> flag:Flag.t
     -> ?rname:Rname.t
     -> ?pos:Pos.t
     -> ?mapq:int

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -59,7 +59,7 @@ module Header : sig
   val parse_header_version : string -> string Or_error.t
   val print_header_version : string -> string
 
-  module Header_line : sig
+  module HD : sig
     (** @HD. A header consists of different types of lines. Confusingly, one of
       these types is called {i the} "header line", which is what this
       type refers to. It does not refer generically to any line within a
@@ -83,7 +83,7 @@ module Header : sig
     val print : t -> string
   end
 
-  module Ref_seq : sig
+  module SQ : sig
     (** @SQ. Reference sequence. *)
     type t = private
       { name : string (** SN *)
@@ -125,7 +125,7 @@ module Header : sig
     val print : t -> string
   end
 
-  module Read_group : sig
+  module RG : sig
     (** @RG. *)
     type t = private
       { id : string (** ID *)
@@ -166,7 +166,7 @@ module Header : sig
     val print : t -> string
   end
 
-  module Program : sig
+  module PG : sig
     (** @PG. *)
     type t = private
       { id : string (** ID *)
@@ -185,10 +185,10 @@ module Header : sig
   module Header_item : sig
     type t =
       private
-      [< `HD of Header_line.t
-      | `SQ of Ref_seq.t
-      | `RG of Read_group.t
-      | `PG of Program.t
+      [< `HD of HD.t
+      | `SQ of SQ.t
+      | `RG of RG.t
+      | `PG of PG.t
       | `CO of string
       | `Other of string * Tag_value.t list
       ]
@@ -216,9 +216,9 @@ module Header : sig
     { version : string option
     ; sort_order : Sort_order.t option
     ; group_order : Group_order.t option
-    ; ref_seqs : Ref_seq.t list
-    ; read_groups : Read_group.t list
-    ; programs : Program.t list
+    ; ref_seqs : SQ.t list
+    ; read_groups : RG.t list
+    ; programs : PG.t list
     ; comments : string list
     ; others : (string * Tag_value.t list) list
     }
@@ -230,9 +230,9 @@ module Header : sig
     :  ?version:string
     -> ?sort_order:Sort_order.t
     -> ?group_order:Group_order.t
-    -> ?ref_seqs:Ref_seq.t list
-    -> ?read_groups:Read_group.t list
-    -> ?programs:Program.t list
+    -> ?ref_seqs:SQ.t list
+    -> ?read_groups:RG.t list
+    -> ?programs:PG.t list
     -> ?comments:string list
     -> ?others:(string * Tag_value.t list) list
     -> unit

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -186,8 +186,13 @@ module Header : sig
       ]
     [@@deriving sexp]
 
-    val of_string : string -> t Or_error.t
-    val to_string : t -> string
+    (** [of_line line] parses the given [line] as a SAM header line.
+        The [line] should not contain the final newline character. *)
+    val of_line : string -> t Or_error.t
+
+    (** [to_line x] converts the header item [x] to a SAM header line.
+        The returned string will not contain the final newline character. *)
+    val to_line : t -> string
   end
 
   (** List of header lines with guarantees:
@@ -411,12 +416,16 @@ module Alignment : sig
     -> unit
     -> t Or_error.t
 
-  val of_string
+  (** [of_line line] parses the given [line] as a SAM alignment line.
+      The [line] should not contain the final newline character. *)
+  val of_line
     :  ?ref_seqs:(string, String.comparator_witness) Set.t
     -> string
     -> t Or_error.t
 
-  val to_string : t -> string
+  (** [to_line x] converts the alignment [x] to a SAM alignment line.
+      The returned string will not contain the final newline character. *)
+  val to_line : t -> string
 end
 
 module Parser : sig

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -176,6 +176,12 @@ module Header : sig
     val print : t -> string
   end
 
+  module Other : sig
+    type t = string * Tag_value.t list [@@deriving sexp]
+
+    val print : t -> string
+  end
+
   module Item : sig
     type t =
       private
@@ -184,14 +190,12 @@ module Header : sig
       | `RG of RG.t
       | `PG of PG.t
       | `CO of string
-      | `Other of string * Tag_value.t list
+      | `Other of Other.t
       ]
     [@@deriving sexp]
 
     val parse : Line.t -> t Or_error.t
   end
-
-  val print_other : string * Tag_value.t list -> string
 
   (**
      - [sort_order]: Guaranteed to be [None] if [version = None].

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -428,35 +428,6 @@ module Alignment : sig
   val to_line : t -> string
 end
 
-module Parser : sig
-  (** State-machine based line-oriented parser. *)
-
-  module State : sig
-    type t =
-      [ `Header of Header.Item.t list (* items in reverse order *)
-      | `Alignment of Header.t * Alignment.t
-      ]
-  end
-
-  type 'a t
-
-  (** [init ~on_alignment ~data] produces an initial parser, ready to parse the
-      first line of a SAM file with initial data set to [data]. The callback
-      [on_alignment] is called on the result of parsing each alignment line,
-      and updates the data. *)
-  val init : on_alignment:('a -> Header.t -> Alignment.t -> 'a) -> data:'a -> 'a t
-
-  val step : 'a t -> string -> 'a t Or_error.t
-  val step_exn : 'a t -> string -> 'a t
-
-  (** [header t] returns the header parsed thus far given current state [t]. *)
-  val header : _ t -> Header.t Or_error.t
-
-  val header_exn : _ t -> Header.t
-  val state : _ t -> State.t
-  val data : 'a t -> 'a
-end
-
 (** [must_be_header line] returns true if the first character of [line] is '@',
     quickly determining that it must be parsed as a header line. *)
 val must_be_header : string -> bool
@@ -464,10 +435,4 @@ val must_be_header : string -> bool
 (** [of_lines lines] parses the given [lines] of a SAM file. *)
 val of_lines : string list -> (Header.t * Alignment.t list) Or_error.t
 
-val of_lines2 : string list -> (Header.t * Alignment.t list) Or_error.t
 val of_lines_exn : string list -> Header.t * Alignment.t list
-
-(** [of_string content] parses the given [content] of a SAM file. *)
-val of_string : string -> (Header.t * Alignment.t list) Or_error.t
-
-val of_string_exn : string -> Header.t * Alignment.t list

--- a/lib/base/sam.mli
+++ b/lib/base/sam.mli
@@ -331,12 +331,17 @@ module Optional_field : sig
   val print_optional_field : t -> string
 end
 
-type rnext =
-  private
-  [< `Value of string
-  | `Equal_to_RNAME
-  ]
-[@@deriving sexp]
+module Rnext : sig
+  type t =
+    private
+    [< `Value of string
+    | `Equal_to_RNAME
+    ]
+  [@@deriving sexp]
+
+  val parse_rnext : string -> t option Or_error.t
+  val print_rnext : t option -> string
+end
 
 (** For [cigar] and [qual], empty list indicates no value, i.e. '*',
     was given. *)
@@ -347,7 +352,7 @@ type alignment = private
   ; pos : int option (** POS *)
   ; mapq : int option (** MAPQ *)
   ; cigar : Cigar_op.t list (** CIGAR *)
-  ; rnext : rnext option (** RNEXT *)
+  ; rnext : Rnext.t option (** RNEXT *)
   ; pnext : int option (** PNEXT *)
   ; tlen : int option (** TLEN *)
   ; seq : string option (** SEQ *)
@@ -368,7 +373,7 @@ val alignment
   -> ?pos:int
   -> ?mapq:int
   -> ?cigar:Cigar_op.t list
-  -> ?rnext:rnext
+  -> ?rnext:Rnext.t
   -> ?pnext:int
   -> ?tlen:int
   -> ?seq:string
@@ -382,7 +387,6 @@ val parse_flags : string -> Flags.t Or_error.t
 val parse_rname : string -> string option Or_error.t
 val parse_pos : string -> int option Or_error.t
 val parse_mapq : string -> int option Or_error.t
-val parse_rnext : string -> rnext option Or_error.t
 val parse_pnext : string -> int option Or_error.t
 val parse_tlen : string -> int option Or_error.t
 val parse_seq : string -> string option Or_error.t
@@ -402,7 +406,6 @@ val print_flags : Flags.t -> string
 val print_rname : string option -> string
 val print_pos : int option -> string
 val print_mapq : int option -> string
-val print_rnext : rnext option -> string
 val print_pnext : int option -> string
 val print_tlen : int option -> string
 val print_seq : string option -> string

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -278,7 +278,7 @@ module Alignment0 = struct
   let qual al =
     let shift = String.map ~f:Char.(fun c -> of_int_exn (to_int c + 33)) in
     match shift al.qual with
-    | qual33 -> Biocaml.Sam.Qual.t_of_string qual33
+    | qual33 -> Biocaml.Sam.Qual.of_string qual33
     | exception Failure _ ->
       Or_error.error
         "Bam.Alignement0.qual: incorrect quality score"
@@ -314,25 +314,25 @@ module Alignment0 = struct
     match typ with
     | 'c' ->
       let i = Int64.of_int_exn (BP.unpack_signed_8 ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.of_int64_i i, len)
     | 'C' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_8 ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.of_int64_i i, len)
     | 's' ->
       let i = Int64.of_int_exn (BP.unpack_signed_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.of_int64_i i, len)
     | 'S' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.of_int64_i i, len)
     | 'i' ->
       let i = BP.unpack_signed_32_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i (Int64.of_int32 i), len)
+      return (Biocaml.Sam.Optional_field.Value.of_int64_i (Int64.of_int32 i), len)
     | 'I' ->
       let i = BP.unpack_unsigned_32_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.of_int64_i i, len)
     | 'f' ->
       let f = BP.unpack_float_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field.Value.t_of_float_f f, len)
+      return (Biocaml.Sam.Optional_field.Value.of_float_f f, len)
     | _ -> error_string "Incorrect numeric optional field type identifier"
   ;;
 
@@ -340,18 +340,18 @@ module Alignment0 = struct
     | 'A' ->
       check_buf ~buf ~pos ~len:1
       >>= fun () ->
-      Biocaml.Sam.Optional_field.Value.t_of_char_A (String.get buf pos)
+      Biocaml.Sam.Optional_field.Value.of_char_A (String.get buf pos)
       >>= fun v -> return (v, 1)
     | ('c' | 'C' | 's' | 'S' | 'i' | 'I' | 'f') as typ -> parse_cCsSiIf buf pos typ
     | 'Z' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.Optional_field.Value.t_of_string_Z s
+      Biocaml.Sam.Optional_field.Value.of_string_Z s
       >>= fun value -> return (value, pos' - pos)
     | 'H' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.Optional_field.Value.t_of_string_H s
+      Biocaml.Sam.Optional_field.Value.of_string_H s
       >>= fun value -> return (value, pos' - pos)
     | 'B' -> (
       check_buf ~buf ~pos ~len:5
@@ -369,7 +369,7 @@ module Alignment0 = struct
             String.sub buf ~pos:(pos + 5 + (i * elt_size)) ~len:elt_size)
         in
         let bytes_read = 5 (* array type and size *) + (elt_size * n) in
-        Biocaml.Sam.Optional_field.Value.t_of_char_string_list_B typ elts
+        Biocaml.Sam.Optional_field.Value.of_char_string_list_B typ elts
         >>= fun value -> return (value, bytes_read)
       | None -> error_string "Too many elements in B-type optional field")
     | c -> error "Incorrect optional field type identifier" c [%sexp_of: char]
@@ -739,18 +739,18 @@ let write_plain_SAM_header h oz =
       |> ok_exn
     in
     (* the construction of the header line must be valid since we are building it from a validated header *)
-    add_line (Biocaml.Sam.Header.HD.string_of_t hl));
+    add_line (Biocaml.Sam.Header.HD.to_string hl));
   List.iter h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.SQ.string_of_t x));
+    add_line (Biocaml.Sam.Header.SQ.to_string x));
   List.iter h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.RG.string_of_t x));
+    add_line (Biocaml.Sam.Header.RG.to_string x));
   List.iter h.Biocaml.Sam.Header.programs ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.PG.string_of_t x));
+    add_line (Biocaml.Sam.Header.PG.to_string x));
   List.iter h.Biocaml.Sam.Header.comments ~f:(fun x ->
     Buffer.add_string buf "@CO\t";
     add_line x);
   List.iter h.Biocaml.Sam.Header.others ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.Other.string_of_t x));
+    add_line (Biocaml.Sam.Header.Other.to_string x));
   Bgzf.output_s32 oz (Int32.of_int_exn (Buffer.length buf));
   (* safe conversion of int32 to int: SAM headers less than a few KB *)
   Bgzf.output_string oz (Buffer.contents buf)

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -278,7 +278,7 @@ module Alignment0 = struct
   let qual al =
     let shift = String.map ~f:Char.(fun c -> of_int_exn (to_int c + 33)) in
     match shift al.qual with
-    | qual33 -> Biocaml.Sam.Alignment.parse_qual qual33
+    | qual33 -> Biocaml.Sam.Qual.parse qual33
     | exception Failure _ ->
       Or_error.error
         "Bam.Alignement0.qual: incorrect quality score"

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -314,26 +314,25 @@ module Alignment0 = struct
     match typ with
     | 'c' ->
       let i = Int64.of_int_exn (BP.unpack_signed_8 ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
     | 'C' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_8 ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
     | 's' ->
       let i = Int64.of_int_exn (BP.unpack_signed_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
     | 'S' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
     | 'i' ->
       let i = BP.unpack_signed_32_little_endian ~buf ~pos in
-      return
-        (Biocaml.Sam.Optional_field_value.optional_field_value_i (Int64.of_int32 i), len)
+      return (Biocaml.Sam.Optional_field.Value.parse_i (Int64.of_int32 i), len)
     | 'I' ->
       let i = BP.unpack_unsigned_32_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
     | 'f' ->
       let f = BP.unpack_float_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field_value.optional_field_value_f f, len)
+      return (Biocaml.Sam.Optional_field.Value.parse_f f, len)
     | _ -> error_string "Incorrect numeric optional field type identifier"
   ;;
 
@@ -341,18 +340,18 @@ module Alignment0 = struct
     | 'A' ->
       check_buf ~buf ~pos ~len:1
       >>= fun () ->
-      Biocaml.Sam.Optional_field_value.optional_field_value_A (String.get buf pos)
+      Biocaml.Sam.Optional_field.Value.parse_A (String.get buf pos)
       >>= fun v -> return (v, 1)
     | ('c' | 'C' | 's' | 'S' | 'i' | 'I' | 'f') as typ -> parse_cCsSiIf buf pos typ
     | 'Z' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.Optional_field_value.optional_field_value_Z s
+      Biocaml.Sam.Optional_field.Value.parse_Z s
       >>= fun value -> return (value, pos' - pos)
     | 'H' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.Optional_field_value.optional_field_value_H s
+      Biocaml.Sam.Optional_field.Value.parse_H s
       >>= fun value -> return (value, pos' - pos)
     | 'B' -> (
       check_buf ~buf ~pos ~len:5
@@ -370,7 +369,7 @@ module Alignment0 = struct
             String.sub buf ~pos:(pos + 5 + (i * elt_size)) ~len:elt_size)
         in
         let bytes_read = 5 (* array type and size *) + (elt_size * n) in
-        Biocaml.Sam.Optional_field_value.optional_field_value_B typ elts
+        Biocaml.Sam.Optional_field.Value.parse_B typ elts
         >>= fun value -> return (value, bytes_read)
       | None -> error_string "Too many elements in B-type optional field")
     | c -> error "Incorrect optional field type identifier" c [%sexp_of: char]

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -736,10 +736,7 @@ let write_plain_SAM_header h oz =
   in
   Option.iter h.Biocaml.Sam.Header.version ~f:(fun version ->
     let hl =
-      Biocaml.Sam.Header.HD.make
-        ~version
-        ?sort_order:h.Biocaml.Sam.Header.sort_order
-        ()
+      Biocaml.Sam.Header.HD.make ~version ?sort_order:h.Biocaml.Sam.Header.sort_order ()
       |> ok_exn
     in
     (* the construction of the header line must be valid since we are building it from a validated header *)
@@ -754,7 +751,7 @@ let write_plain_SAM_header h oz =
     Buffer.add_string buf "@CO\t";
     add_line x);
   List.iter h.Biocaml.Sam.Header.others ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.print_other x));
+    add_line (Biocaml.Sam.Header.Other.print x));
   Bgzf.output_s32 oz (Int32.of_int_exn (Buffer.length buf));
   (* safe conversion of int32 to int: SAM headers less than a few KB *)
   Bgzf.output_string oz (Buffer.contents buf)

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -767,7 +767,7 @@ let write_plain_SAM_header (h : Biocaml.Sam.Header.t) oz =
   in
   List.iter
     (h :> Biocaml.Sam.Header.Item.t list)
-    ~f:(fun x -> add_line (Biocaml.Sam.Header.Item.to_string x));
+    ~f:(fun x -> add_line (Biocaml.Sam.Header.Item.to_line x));
   Bgzf.output_s32 oz (Int32.of_int_exn (Buffer.length buf));
   (* safe conversion of int32 to int: SAM headers less than a few KB *)
   Bgzf.output_string oz (Buffer.contents buf)

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -193,7 +193,7 @@ module Alignment0 = struct
     Int32.shift_right al.flag_nc 16
     |> Int32.to_int_exn
        (* because we are shifting right just before, Int32.to_int_exn cannot fail *)
-    |> Biocaml.Sam.Flags.of_int
+    |> Biocaml.Sam.Flag.of_int
   ;;
 
   let rname al header =
@@ -408,7 +408,7 @@ module Alignment0 = struct
   (* Alignement0.t -> Alignment.t conversion *)
   let decode al header =
     flags al
-    >>= fun flags ->
+    >>= fun flag ->
     rname al header
     >>= fun rname ->
     cigar al
@@ -421,7 +421,7 @@ module Alignment0 = struct
     >>= fun optional_fields ->
     Biocaml.Sam.Alignment.make
       ?qname:(qname al)
-      ~flags
+      ~flag
       ?rname
       ?pos:(pos al)
       ?mapq:(mapq al)
@@ -563,7 +563,7 @@ module Alignment0 = struct
     (* NULL terminated string *)
     encode_bin_mq_nl ~bin ~mapq ~l_read_name
     >>= fun bin_mq_nl ->
-    let flags = (al.Biocaml.Sam.Alignment.flags :> int) in
+    let flags = (al.Biocaml.Sam.Alignment.flag :> int) in
     let n_cigar_ops = List.length al.Biocaml.Sam.Alignment.cigar in
     encode_flag_nc ~flags ~n_cigar_ops
     >>= fun flag_nc ->

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -383,7 +383,7 @@ module Alignment0 = struct
     let field_type = buf.[pos + 2] in
     parse_optional_field_value buf (pos + 3) field_type
     >>= fun (field_value, shift) ->
-    Biocaml.Sam.Optional_field.optional_field tag field_value
+    Biocaml.Sam.Optional_field.make tag field_value
     >>= fun field -> return (field, shift + 3)
   ;;
 
@@ -420,7 +420,7 @@ module Alignment0 = struct
     >>= fun qual ->
     optional_fields al
     >>= fun optional_fields ->
-    Biocaml.Sam.Alignment.alignment
+    Biocaml.Sam.Alignment.make
       ?qname:(qname al)
       ~flags
       ?rname
@@ -626,7 +626,7 @@ let read_one_reference_information iz =
     let (_ : char) = Bgzf.input_char iz in
     (* name is a NULL terminated string *)
     let length = input_s32_as_int iz in
-    Biocaml.Sam.Header.SQ.ref_seq ~name ~length ()
+    Biocaml.Sam.Header.SQ.make ~name ~length ()
   with
   | End_of_file -> error_string "EOF while reading BAM reference information"
 ;;
@@ -736,7 +736,7 @@ let write_plain_SAM_header h oz =
   in
   Option.iter h.Biocaml.Sam.Header.version ~f:(fun version ->
     let hl =
-      Biocaml.Sam.Header.HD.header_line
+      Biocaml.Sam.Header.HD.make
         ~version
         ?sort_order:h.Biocaml.Sam.Header.sort_order
         ()

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -146,20 +146,20 @@ module Header = struct
      but makes parsing faster because in Bam, the seq name of a read
      is stored as an int index in the ref_seq array. *)
   type t =
-    { ref_seq : Biocaml.Sam.ref_seq array
-    ; sam_header : Biocaml.Sam.header
+    { ref_seq : Biocaml.Sam.Header.Ref_seq.t array
+    ; sam_header : Biocaml.Sam.Header.t
     }
 
   let to_sam h = h.sam_header
 
   let of_sam sam_header =
-    { ref_seq = Array.of_list sam_header.Biocaml.Sam.ref_seqs; sam_header }
+    { ref_seq = Array.of_list sam_header.Biocaml.Sam.Header.ref_seqs; sam_header }
   ;;
 end
 
 open Header
 
-type alignment = Biocaml.Sam.alignment
+type alignment = Biocaml.Sam.Alignment.t
 
 module Alignment0 = struct
   type t =
@@ -197,29 +197,25 @@ module Alignment0 = struct
   ;;
 
   let rname al header =
-    try
-      Ok
-        (Option.map (ref_id al) ~f:(fun id ->
-           (Array.get header.ref_seq id).Biocaml.Sam.name))
-    with
+    try Ok (Option.map (ref_id al) ~f:(fun id -> (Array.get header.ref_seq id).name)) with
     | _ -> error_string "Bam.Alignment0.rname: unknown ref_id"
   ;;
 
   let pos al = option ~none:(-1) al.pos
   let mapq al = option ~none:255 (get_16_8 al.bin_mq_nl)
 
-  let cigar_op_of_s32 x : Biocaml.Sam.cigar_op Or_error.t =
+  let cigar_op_of_s32 x : Biocaml.Sam.Cigar_op.t Or_error.t =
     let op_len = get_32_4 x in
     match get_4_0 x with
-    | 0 -> Biocaml.Sam.cigar_op_alignment_match op_len
-    | 1 -> Biocaml.Sam.cigar_op_insertion op_len
-    | 2 -> Biocaml.Sam.cigar_op_deletion op_len
-    | 3 -> Biocaml.Sam.cigar_op_skipped op_len
-    | 4 -> Biocaml.Sam.cigar_op_soft_clipping op_len
-    | 5 -> Biocaml.Sam.cigar_op_hard_clipping op_len
-    | 6 -> Biocaml.Sam.cigar_op_padding op_len
-    | 7 -> Biocaml.Sam.cigar_op_seq_match op_len
-    | 8 -> Biocaml.Sam.cigar_op_seq_mismatch op_len
+    | 0 -> Biocaml.Sam.Cigar_op.cigar_op_alignment_match op_len
+    | 1 -> Biocaml.Sam.Cigar_op.cigar_op_insertion op_len
+    | 2 -> Biocaml.Sam.Cigar_op.cigar_op_deletion op_len
+    | 3 -> Biocaml.Sam.Cigar_op.cigar_op_skipped op_len
+    | 4 -> Biocaml.Sam.Cigar_op.cigar_op_soft_clipping op_len
+    | 5 -> Biocaml.Sam.Cigar_op.cigar_op_hard_clipping op_len
+    | 6 -> Biocaml.Sam.Cigar_op.cigar_op_padding op_len
+    | 7 -> Biocaml.Sam.Cigar_op.cigar_op_seq_match op_len
+    | 8 -> Biocaml.Sam.Cigar_op.cigar_op_seq_mismatch op_len
     | _ -> assert false
   ;;
 
@@ -234,7 +230,7 @@ module Alignment0 = struct
   let rnext al header =
     match al.next_ref_id with
     | -1 -> return None
-    | i -> Biocaml.Sam.parse_rnext header.ref_seq.(i).Biocaml.Sam.name
+    | i -> Biocaml.Sam.Rnext.parse header.ref_seq.(i).name
   ;;
 
   let pnext al = option ~none:(-1) al.pnext
@@ -282,7 +278,7 @@ module Alignment0 = struct
   let qual al =
     let shift = String.map ~f:Char.(fun c -> of_int_exn (to_int c + 33)) in
     match shift al.qual with
-    | qual33 -> Biocaml.Sam.parse_qual qual33
+    | qual33 -> Biocaml.Sam.Alignment.parse_qual qual33
     | exception Failure _ ->
       Or_error.error
         "Bam.Alignement0.qual: incorrect quality score"
@@ -318,25 +314,26 @@ module Alignment0 = struct
     match typ with
     | 'c' ->
       let i = Int64.of_int_exn (BP.unpack_signed_8 ~buf ~pos) in
-      return (Biocaml.Sam.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
     | 'C' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_8 ~buf ~pos) in
-      return (Biocaml.Sam.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
     | 's' ->
       let i = Int64.of_int_exn (BP.unpack_signed_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
     | 'S' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
     | 'i' ->
       let i = BP.unpack_signed_32_little_endian ~buf ~pos in
-      return (Biocaml.Sam.optional_field_value_i (Int64.of_int32 i), len)
+      return
+        (Biocaml.Sam.Optional_field_value.optional_field_value_i (Int64.of_int32 i), len)
     | 'I' ->
       let i = BP.unpack_unsigned_32_little_endian ~buf ~pos in
-      return (Biocaml.Sam.optional_field_value_i i, len)
+      return (Biocaml.Sam.Optional_field_value.optional_field_value_i i, len)
     | 'f' ->
       let f = BP.unpack_float_little_endian ~buf ~pos in
-      return (Biocaml.Sam.optional_field_value_f f, len)
+      return (Biocaml.Sam.Optional_field_value.optional_field_value_f f, len)
     | _ -> error_string "Incorrect numeric optional field type identifier"
   ;;
 
@@ -344,16 +341,19 @@ module Alignment0 = struct
     | 'A' ->
       check_buf ~buf ~pos ~len:1
       >>= fun () ->
-      Biocaml.Sam.optional_field_value_A (String.get buf pos) >>= fun v -> return (v, 1)
+      Biocaml.Sam.Optional_field_value.optional_field_value_A (String.get buf pos)
+      >>= fun v -> return (v, 1)
     | ('c' | 'C' | 's' | 'S' | 'i' | 'I' | 'f') as typ -> parse_cCsSiIf buf pos typ
     | 'Z' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.optional_field_value_Z s >>= fun value -> return (value, pos' - pos)
+      Biocaml.Sam.Optional_field_value.optional_field_value_Z s
+      >>= fun value -> return (value, pos' - pos)
     | 'H' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.optional_field_value_H s >>= fun value -> return (value, pos' - pos)
+      Biocaml.Sam.Optional_field_value.optional_field_value_H s
+      >>= fun value -> return (value, pos' - pos)
     | 'B' -> (
       check_buf ~buf ~pos ~len:5
       >>= fun () ->
@@ -370,7 +370,7 @@ module Alignment0 = struct
             String.sub buf ~pos:(pos + 5 + (i * elt_size)) ~len:elt_size)
         in
         let bytes_read = 5 (* array type and size *) + (elt_size * n) in
-        Biocaml.Sam.optional_field_value_B typ elts
+        Biocaml.Sam.Optional_field_value.optional_field_value_B typ elts
         >>= fun value -> return (value, bytes_read)
       | None -> error_string "Too many elements in B-type optional field")
     | c -> error "Incorrect optional field type identifier" c [%sexp_of: char]
@@ -383,7 +383,8 @@ module Alignment0 = struct
     let field_type = buf.[pos + 2] in
     parse_optional_field_value buf (pos + 3) field_type
     >>= fun (field_value, shift) ->
-    Biocaml.Sam.optional_field tag field_value >>= fun field -> return (field, shift + 3)
+    Biocaml.Sam.Optional_field.optional_field tag field_value
+    >>= fun field -> return (field, shift + 3)
   ;;
 
   let parse_optional_fields buf =
@@ -419,7 +420,7 @@ module Alignment0 = struct
     >>= fun qual ->
     optional_fields al
     >>= fun optional_fields ->
-    Biocaml.Sam.alignment
+    Biocaml.Sam.Alignment.alignment
       ?qname:(qname al)
       ~flags
       ?rname
@@ -442,9 +443,7 @@ module Alignment0 = struct
   (* Alignment.t -> Alignment0.t conversion *)
   let find_ref_id header ref_name =
     let open Or_error in
-    match
-      Array.findi header.ref_seq ~f:(fun _ rs -> String.(rs.Biocaml.Sam.name = ref_name))
-    with
+    match Array.findi header.ref_seq ~f:(fun _ rs -> String.(rs.name = ref_name)) with
     | Some (i, _) -> Ok i
     | None -> error_string "Bam: unknown reference id"
   ;;
@@ -517,8 +516,8 @@ module Alignment0 = struct
     in
     let open Or_error.Monad_infix in
     List.map opt_fields ~f:(fun opt_field ->
-      field_value_encoding opt_field.Biocaml.Sam.value
-      >>= fun (c, s) -> Ok (sprintf "%s%c%s" opt_field.Biocaml.Sam.tag c s))
+      field_value_encoding opt_field.Biocaml.Sam.Optional_field.value
+      >>= fun (c, s) -> Ok (sprintf "%s%c%s" opt_field.Biocaml.Sam.Optional_field.tag c s))
     |> Or_error.all
     >>| String.concat ~sep:""
   ;;
@@ -552,35 +551,37 @@ module Alignment0 = struct
   ;;
 
   let encode al header =
-    (match al.Biocaml.Sam.rname with
+    (match al.Biocaml.Sam.Alignment.rname with
      | Some rname -> find_ref_id header rname
      | None -> Ok (-1))
     >>= fun ref_id ->
-    let read_name = Option.value ~default:"*" al.Biocaml.Sam.qname in
-    let seq = Option.value ~default:"*" al.Biocaml.Sam.seq in
-    let pos = Option.value ~default:0 al.Biocaml.Sam.pos - 1 in
+    let read_name = Option.value ~default:"*" al.Biocaml.Sam.Alignment.qname in
+    let seq = Option.value ~default:"*" al.Biocaml.Sam.Alignment.seq in
+    let pos = Option.value ~default:0 al.Biocaml.Sam.Alignment.pos - 1 in
     let bin = reg2bin pos (pos + String.(length seq)) in
-    let mapq = Option.value ~default:255 al.Biocaml.Sam.mapq in
+    let mapq = Option.value ~default:255 al.Biocaml.Sam.Alignment.mapq in
     let l_read_name = String.length read_name + 1 in
     (* NULL terminated string *)
     encode_bin_mq_nl ~bin ~mapq ~l_read_name
     >>= fun bin_mq_nl ->
-    let flags = (al.Biocaml.Sam.flags :> int) in
-    let n_cigar_ops = List.length al.Biocaml.Sam.cigar in
+    let flags = (al.Biocaml.Sam.Alignment.flags :> int) in
+    let n_cigar_ops = List.length al.Biocaml.Sam.Alignment.cigar in
     encode_flag_nc ~flags ~n_cigar_ops
     >>= fun flag_nc ->
-    (match al.Biocaml.Sam.rnext with
+    (match al.Biocaml.Sam.Alignment.rnext with
      | Some `Equal_to_RNAME -> Ok ref_id
      | Some (`Value s) -> find_ref_id header s
      | None -> Ok (-1))
     >>= fun next_ref_id ->
-    let pnext = Option.value ~default:0 al.Biocaml.Sam.pnext - 1 in
-    let tlen = Option.value ~default:0 al.Biocaml.Sam.tlen in
-    let cigar = string_of_cigar_ops al.Biocaml.Sam.cigar in
-    Result.List.map al.Biocaml.Sam.qual ~f:(Biocaml.Phred_score.to_char ~offset:`Offset33)
+    let pnext = Option.value ~default:0 al.Biocaml.Sam.Alignment.pnext - 1 in
+    let tlen = Option.value ~default:0 al.Biocaml.Sam.Alignment.tlen in
+    let cigar = string_of_cigar_ops al.Biocaml.Sam.Alignment.cigar in
+    Result.List.map
+      al.Biocaml.Sam.Alignment.qual
+      ~f:(Biocaml.Phred_score.to_char ~offset:`Offset33)
     >>| String.of_char_list
     >>= fun qual ->
-    string_of_optional_fields al.Biocaml.Sam.optional_fields
+    string_of_optional_fields al.Biocaml.Sam.Alignment.optional_fields
     >>= fun optional ->
     Ok
       { ref_id
@@ -625,7 +626,7 @@ let read_one_reference_information iz =
     let (_ : char) = Bgzf.input_char iz in
     (* name is a NULL terminated string *)
     let length = input_s32_as_int iz in
-    Biocaml.Sam.ref_seq ~name ~length ()
+    Biocaml.Sam.Header.Ref_seq.ref_seq ~name ~length ()
   with
   | End_of_file -> error_string "EOF while reading BAM reference information"
 ;;
@@ -733,17 +734,27 @@ let write_plain_SAM_header h oz =
     Buffer.add_string buf x;
     Buffer.add_char buf '\n'
   in
-  Option.iter h.Biocaml.Sam.version ~f:(fun version ->
-    let hl = Biocaml.Sam.header_line ~version ?sort_order:h.sort_order () |> ok_exn in
+  Option.iter h.Biocaml.Sam.Header.version ~f:(fun version ->
+    let hl =
+      Biocaml.Sam.Header.Header_line.header_line
+        ~version
+        ?sort_order:h.Biocaml.Sam.Header.sort_order
+        ()
+      |> ok_exn
+    in
     (* the construction of the header line must be valid since we are building it from a validated header *)
-    add_line (Biocaml.Sam.print_header_line hl));
-  List.iter h.ref_seqs ~f:(fun x -> add_line (Biocaml.Sam.print_ref_seq x));
-  List.iter h.read_groups ~f:(fun x -> add_line (Biocaml.Sam.print_read_group x));
-  List.iter h.programs ~f:(fun x -> add_line (Biocaml.Sam.print_program x));
-  List.iter h.comments ~f:(fun x ->
+    add_line (Biocaml.Sam.Header.Header_line.print hl));
+  List.iter h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
+    add_line (Biocaml.Sam.Header.Ref_seq.print x));
+  List.iter h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
+    add_line (Biocaml.Sam.Header.Read_group.print x));
+  List.iter h.Biocaml.Sam.Header.programs ~f:(fun x ->
+    add_line (Biocaml.Sam.Header.Program.print x));
+  List.iter h.Biocaml.Sam.Header.comments ~f:(fun x ->
     Buffer.add_string buf "@CO\t";
     add_line x);
-  List.iter h.others ~f:(fun x -> add_line (Biocaml.Sam.print_other x));
+  List.iter h.Biocaml.Sam.Header.others ~f:(fun x ->
+    add_line (Biocaml.Sam.Header.print_other x));
   Bgzf.output_s32 oz (Int32.of_int_exn (Buffer.length buf));
   (* safe conversion of int32 to int: SAM headers less than a few KB *)
   Bgzf.output_string oz (Buffer.contents buf)
@@ -854,41 +865,33 @@ module Test = struct
 
   let assert_headers h1 h2 =
     let h1, h2 = Header.to_sam h1, Header.to_sam h2 in
-    assert_equal
-      ~msg:"version"
-      ~printer:[%sexp_of: string option]
-      h1.Biocaml.Sam.version
-      h2.Biocaml.Sam.version;
+    assert_equal ~msg:"version" ~printer:[%sexp_of: string option] h1.version h2.version;
     assert_equal
       ~msg:"sort_order"
-      ~printer:[%sexp_of: Biocaml.Sam.sort_order option]
-      h1.Biocaml.Sam.sort_order
-      h2.Biocaml.Sam.sort_order;
+      ~printer:[%sexp_of: Biocaml.Sam.Header.Sort_order.t option]
+      h1.sort_order
+      h2.sort_order;
     assert_equal
       ~msg:"ref_seqs"
-      ~printer:[%sexp_of: Biocaml.Sam.ref_seq list]
-      h1.Biocaml.Sam.ref_seqs
-      h2.Biocaml.Sam.ref_seqs;
+      ~printer:[%sexp_of: Biocaml.Sam.Header.Ref_seq.t list]
+      h1.ref_seqs
+      h2.ref_seqs;
     assert_equal
       ~msg:"read_groups"
-      ~printer:[%sexp_of: Biocaml.Sam.read_group list]
-      h1.Biocaml.Sam.read_groups
-      h2.Biocaml.Sam.read_groups;
+      ~printer:[%sexp_of: Biocaml.Sam.Header.Read_group.t list]
+      h1.read_groups
+      h2.read_groups;
     assert_equal
       ~msg:"programs"
-      ~printer:[%sexp_of: Biocaml.Sam.program list]
-      h1.Biocaml.Sam.programs
-      h2.Biocaml.Sam.programs;
-    assert_equal
-      ~msg:"comments"
-      ~printer:[%sexp_of: string list]
-      h1.Biocaml.Sam.comments
-      h2.Biocaml.Sam.comments;
+      ~printer:[%sexp_of: Biocaml.Sam.Header.Program.t list]
+      h1.programs
+      h2.programs;
+    assert_equal ~msg:"comments" ~printer:[%sexp_of: string list] h1.comments h2.comments;
     assert_equal
       ~msg:"others"
-      ~printer:[%sexp_of: (string * Biocaml.Sam.tag_value list) list]
-      h1.Biocaml.Sam.others
-      h2.Biocaml.Sam.others;
+      ~printer:[%sexp_of: (string * Biocaml.Sam.Header.Tag_value.t list) list]
+      h1.others
+      h2.others;
     ()
   ;;
 
@@ -960,13 +963,13 @@ module Test = struct
         ~msg:"Sam version"
         ~printer:[%sexp_of: string option]
         (Some "1.0")
-        sh.Biocaml.Sam.version;
-      assert_equal ~msg:"Sort order" (Some `Unsorted) sh.Biocaml.Sam.sort_order;
+        sh.version;
+      assert_equal ~msg:"Sort order" (Some `Unsorted) sh.sort_order;
       assert_equal
         ~msg:"Number of ref sequences"
         ~printer:Int.sexp_of_t
         22
-        (List.length sh.Biocaml.Sam.ref_seqs);
+        (List.length sh.ref_seqs);
       let al0 = CFStream.next_exn alignments |> ok_exn in
       assert_alignment
         ~qname:(Some "ILLUMINA-D118D2_0040_FC:7:20:2683:16044#0/1")

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -204,18 +204,18 @@ module Alignment0 = struct
   let pos al = option ~none:(-1) al.pos
   let mapq al = option ~none:255 (get_16_8 al.bin_mq_nl)
 
-  let cigar_op_of_s32 x : Biocaml.Sam.Cigar_op.t Or_error.t =
+  let cigar_op_of_s32 x : Biocaml.Sam.Cigar.Op.t Or_error.t =
     let op_len = get_32_4 x in
     match get_4_0 x with
-    | 0 -> Biocaml.Sam.Cigar_op.cigar_op_alignment_match op_len
-    | 1 -> Biocaml.Sam.Cigar_op.cigar_op_insertion op_len
-    | 2 -> Biocaml.Sam.Cigar_op.cigar_op_deletion op_len
-    | 3 -> Biocaml.Sam.Cigar_op.cigar_op_skipped op_len
-    | 4 -> Biocaml.Sam.Cigar_op.cigar_op_soft_clipping op_len
-    | 5 -> Biocaml.Sam.Cigar_op.cigar_op_hard_clipping op_len
-    | 6 -> Biocaml.Sam.Cigar_op.cigar_op_padding op_len
-    | 7 -> Biocaml.Sam.Cigar_op.cigar_op_seq_match op_len
-    | 8 -> Biocaml.Sam.Cigar_op.cigar_op_seq_mismatch op_len
+    | 0 -> Biocaml.Sam.Cigar.Op.alignment_match_of_int op_len
+    | 1 -> Biocaml.Sam.Cigar.Op.insertion_of_int op_len
+    | 2 -> Biocaml.Sam.Cigar.Op.deletion_of_int op_len
+    | 3 -> Biocaml.Sam.Cigar.Op.skipped_of_int op_len
+    | 4 -> Biocaml.Sam.Cigar.Op.soft_clipping_of_int op_len
+    | 5 -> Biocaml.Sam.Cigar.Op.hard_clipping_of_int op_len
+    | 6 -> Biocaml.Sam.Cigar.Op.padding_of_int op_len
+    | 7 -> Biocaml.Sam.Cigar.Op.seq_match_of_int op_len
+    | 8 -> Biocaml.Sam.Cigar.Op.seq_mismatch_of_int op_len
     | _ -> assert false
   ;;
 

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -146,7 +146,7 @@ module Header = struct
      but makes parsing faster because in Bam, the seq name of a read
      is stored as an int index in the ref_seq array. *)
   type t =
-    { ref_seq : Biocaml.Sam.Header.Ref_seq.t array
+    { ref_seq : Biocaml.Sam.Header.SQ.t array
     ; sam_header : Biocaml.Sam.Header.t
     }
 
@@ -626,7 +626,7 @@ let read_one_reference_information iz =
     let (_ : char) = Bgzf.input_char iz in
     (* name is a NULL terminated string *)
     let length = input_s32_as_int iz in
-    Biocaml.Sam.Header.Ref_seq.ref_seq ~name ~length ()
+    Biocaml.Sam.Header.SQ.ref_seq ~name ~length ()
   with
   | End_of_file -> error_string "EOF while reading BAM reference information"
 ;;
@@ -736,20 +736,20 @@ let write_plain_SAM_header h oz =
   in
   Option.iter h.Biocaml.Sam.Header.version ~f:(fun version ->
     let hl =
-      Biocaml.Sam.Header.Header_line.header_line
+      Biocaml.Sam.Header.HD.header_line
         ~version
         ?sort_order:h.Biocaml.Sam.Header.sort_order
         ()
       |> ok_exn
     in
     (* the construction of the header line must be valid since we are building it from a validated header *)
-    add_line (Biocaml.Sam.Header.Header_line.print hl));
+    add_line (Biocaml.Sam.Header.HD.print hl));
   List.iter h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.Ref_seq.print x));
+    add_line (Biocaml.Sam.Header.SQ.print x));
   List.iter h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.Read_group.print x));
+    add_line (Biocaml.Sam.Header.RG.print x));
   List.iter h.Biocaml.Sam.Header.programs ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.Program.print x));
+    add_line (Biocaml.Sam.Header.PG.print x));
   List.iter h.Biocaml.Sam.Header.comments ~f:(fun x ->
     Buffer.add_string buf "@CO\t";
     add_line x);
@@ -873,17 +873,17 @@ module Test = struct
       h2.sort_order;
     assert_equal
       ~msg:"ref_seqs"
-      ~printer:[%sexp_of: Biocaml.Sam.Header.Ref_seq.t list]
+      ~printer:[%sexp_of: Biocaml.Sam.Header.SQ.t list]
       h1.ref_seqs
       h2.ref_seqs;
     assert_equal
       ~msg:"read_groups"
-      ~printer:[%sexp_of: Biocaml.Sam.Header.Read_group.t list]
+      ~printer:[%sexp_of: Biocaml.Sam.Header.RG.t list]
       h1.read_groups
       h2.read_groups;
     assert_equal
       ~msg:"programs"
-      ~printer:[%sexp_of: Biocaml.Sam.Header.Program.t list]
+      ~printer:[%sexp_of: Biocaml.Sam.Header.PG.t list]
       h1.programs
       h2.programs;
     assert_equal ~msg:"comments" ~printer:[%sexp_of: string list] h1.comments h2.comments;

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -230,7 +230,7 @@ module Alignment0 = struct
   let rnext al header =
     match al.next_ref_id with
     | -1 -> return None
-    | i -> Biocaml.Sam.Rnext.parse header.ref_seq.(i).name
+    | i -> Biocaml.Sam.Rnext.t_option_of_string header.ref_seq.(i).name
   ;;
 
   let pnext al = option ~none:(-1) al.pnext
@@ -278,7 +278,7 @@ module Alignment0 = struct
   let qual al =
     let shift = String.map ~f:Char.(fun c -> of_int_exn (to_int c + 33)) in
     match shift al.qual with
-    | qual33 -> Biocaml.Sam.Qual.parse qual33
+    | qual33 -> Biocaml.Sam.Qual.t_of_string qual33
     | exception Failure _ ->
       Or_error.error
         "Bam.Alignement0.qual: incorrect quality score"
@@ -314,25 +314,25 @@ module Alignment0 = struct
     match typ with
     | 'c' ->
       let i = Int64.of_int_exn (BP.unpack_signed_8 ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
     | 'C' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_8 ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
     | 's' ->
       let i = Int64.of_int_exn (BP.unpack_signed_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
     | 'S' ->
       let i = Int64.of_int_exn (BP.unpack_unsigned_16_little_endian ~buf ~pos) in
-      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
     | 'i' ->
       let i = BP.unpack_signed_32_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field.Value.parse_i (Int64.of_int32 i), len)
+      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i (Int64.of_int32 i), len)
     | 'I' ->
       let i = BP.unpack_unsigned_32_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field.Value.parse_i i, len)
+      return (Biocaml.Sam.Optional_field.Value.t_of_int64_i i, len)
     | 'f' ->
       let f = BP.unpack_float_little_endian ~buf ~pos in
-      return (Biocaml.Sam.Optional_field.Value.parse_f f, len)
+      return (Biocaml.Sam.Optional_field.Value.t_of_float_f f, len)
     | _ -> error_string "Incorrect numeric optional field type identifier"
   ;;
 
@@ -340,18 +340,18 @@ module Alignment0 = struct
     | 'A' ->
       check_buf ~buf ~pos ~len:1
       >>= fun () ->
-      Biocaml.Sam.Optional_field.Value.parse_A (String.get buf pos)
+      Biocaml.Sam.Optional_field.Value.t_of_char_A (String.get buf pos)
       >>= fun v -> return (v, 1)
     | ('c' | 'C' | 's' | 'S' | 'i' | 'I' | 'f') as typ -> parse_cCsSiIf buf pos typ
     | 'Z' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.Optional_field.Value.parse_Z s
+      Biocaml.Sam.Optional_field.Value.t_of_string_Z s
       >>= fun value -> return (value, pos' - pos)
     | 'H' ->
       parse_cstring buf pos
       >>= fun (s, pos') ->
-      Biocaml.Sam.Optional_field.Value.parse_H s
+      Biocaml.Sam.Optional_field.Value.t_of_string_H s
       >>= fun value -> return (value, pos' - pos)
     | 'B' -> (
       check_buf ~buf ~pos ~len:5
@@ -369,7 +369,7 @@ module Alignment0 = struct
             String.sub buf ~pos:(pos + 5 + (i * elt_size)) ~len:elt_size)
         in
         let bytes_read = 5 (* array type and size *) + (elt_size * n) in
-        Biocaml.Sam.Optional_field.Value.parse_B typ elts
+        Biocaml.Sam.Optional_field.Value.t_of_char_string_list_B typ elts
         >>= fun value -> return (value, bytes_read)
       | None -> error_string "Too many elements in B-type optional field")
     | c -> error "Incorrect optional field type identifier" c [%sexp_of: char]
@@ -739,18 +739,18 @@ let write_plain_SAM_header h oz =
       |> ok_exn
     in
     (* the construction of the header line must be valid since we are building it from a validated header *)
-    add_line (Biocaml.Sam.Header.HD.print hl));
+    add_line (Biocaml.Sam.Header.HD.string_of_t hl));
   List.iter h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.SQ.print x));
+    add_line (Biocaml.Sam.Header.SQ.string_of_t x));
   List.iter h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.RG.print x));
+    add_line (Biocaml.Sam.Header.RG.string_of_t x));
   List.iter h.Biocaml.Sam.Header.programs ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.PG.print x));
+    add_line (Biocaml.Sam.Header.PG.string_of_t x));
   List.iter h.Biocaml.Sam.Header.comments ~f:(fun x ->
     Buffer.add_string buf "@CO\t";
     add_line x);
   List.iter h.Biocaml.Sam.Header.others ~f:(fun x ->
-    add_line (Biocaml.Sam.Header.Other.print x));
+    add_line (Biocaml.Sam.Header.Other.string_of_t x));
   Bgzf.output_s32 oz (Int32.of_int_exn (Buffer.length buf));
   (* safe conversion of int32 to int: SAM headers less than a few KB *)
   Bgzf.output_string oz (Buffer.contents buf)

--- a/lib/unix/bam.ml
+++ b/lib/unix/bam.ml
@@ -868,7 +868,7 @@ module Test = struct
     assert_equal ~msg:"version" ~printer:[%sexp_of: string option] h1.version h2.version;
     assert_equal
       ~msg:"sort_order"
-      ~printer:[%sexp_of: Biocaml.Sam.Header.Sort_order.t option]
+      ~printer:[%sexp_of: Biocaml.Sam.Header.HD.SO.t option]
       h1.sort_order
       h2.sort_order;
     assert_equal

--- a/lib/unix/bam.mli
+++ b/lib/unix/bam.mli
@@ -29,7 +29,8 @@ type alignment = Biocaml.Sam.Alignment.t
 module Alignment0 : sig
   type t [@@deriving sexp]
 
-  val qname : t -> string option
+  val qname : t -> Biocaml.Sam.Qname.t option Or_error.t
+  val qname2 : t -> string option
   val flags : t -> Biocaml.Sam.Flag.t Or_error.t
   val ref_id : t -> int option
   val rname : t -> Header.t -> string option Or_error.t

--- a/lib/unix/bam.mli
+++ b/lib/unix/bam.mli
@@ -30,7 +30,7 @@ module Alignment0 : sig
   type t [@@deriving sexp]
 
   val qname : t -> string option
-  val flags : t -> Biocaml.Sam.Flags.t Or_error.t
+  val flags : t -> Biocaml.Sam.Flag.t Or_error.t
   val ref_id : t -> int option
   val rname : t -> Header.t -> string option Or_error.t
 

--- a/lib/unix/bam.mli
+++ b/lib/unix/bam.mli
@@ -14,11 +14,11 @@
 module Header : sig
   type t
 
-  val of_sam : Biocaml.Sam.header -> t
-  val to_sam : t -> Biocaml.Sam.header
+  val of_sam : Biocaml.Sam.Header.t -> t
+  val to_sam : t -> Biocaml.Sam.Header.t
 end
 
-type alignment = Biocaml.Sam.alignment
+type alignment = Biocaml.Sam.Alignment.t
 
 (** Representation of partially parsed alignments. When traversing a
     BAM file for a specific calculation, it may be that only some
@@ -38,13 +38,13 @@ module Alignment0 : sig
   val pos : t -> int option
 
   val mapq : t -> int option
-  val cigar : t -> Biocaml.Sam.cigar_op list Or_error.t
-  val rnext : t -> Header.t -> Biocaml.Sam.rnext option Or_error.t
+  val cigar : t -> Biocaml.Sam.Cigar_op.t list Or_error.t
+  val rnext : t -> Header.t -> Biocaml.Sam.Rnext.t option Or_error.t
   val pnext : t -> int option
   val tlen : t -> int option
   val seq : t -> string option
   val qual : t -> Biocaml.Phred_score.t list Or_error.t
-  val optional_fields : t -> Biocaml.Sam.optional_field list Or_error.t
+  val optional_fields : t -> Biocaml.Sam.Optional_field.t list Or_error.t
   val decode : t -> Header.t -> alignment Or_error.t
   val encode : alignment -> Header.t -> t Or_error.t
 end

--- a/lib/unix/bam.mli
+++ b/lib/unix/bam.mli
@@ -38,7 +38,7 @@ module Alignment0 : sig
   val pos : t -> int option
 
   val mapq : t -> int option
-  val cigar : t -> Biocaml.Sam.Cigar_op.t list Or_error.t
+  val cigar : t -> Biocaml.Sam.Cigar.t Or_error.t
   val rnext : t -> Header.t -> Biocaml.Sam.Rnext.t option Or_error.t
   val pnext : t -> int option
   val tlen : t -> int option

--- a/lib/unix/bam.mli
+++ b/lib/unix/bam.mli
@@ -29,8 +29,7 @@ type alignment = Biocaml.Sam.Alignment.t
 module Alignment0 : sig
   type t [@@deriving sexp]
 
-  val qname : t -> Biocaml.Sam.Qname.t option Or_error.t
-  val qname2 : t -> string option
+  val qname : t -> string option
   val flags : t -> Biocaml.Sam.Flag.t Or_error.t
   val ref_id : t -> int option
   val rname : t -> Header.t -> string option Or_error.t

--- a/lib/unix/bamstats.ml
+++ b/lib/unix/bamstats.ml
@@ -29,7 +29,7 @@ let zero =
 let incr_if b i = if b then i + 1 else i
 
 let update_gen s flags =
-  let open Biocaml.Sam.Flags in
+  let open Biocaml.Sam.Flag in
   let total = s.total + 1 in
   if not_passing_quality_controls flags
   then { s with total }
@@ -49,7 +49,7 @@ let update_gen s flags =
     { total; qc_pass; single_reads; read_pairs; mapped_reads; mapped_pairs })
 ;;
 
-let update s al = update_gen s al.Biocaml.Sam.Alignment.flags
+let update s al = update_gen s al.Biocaml.Sam.Alignment.flag
 
 let update0 s al =
   let open Or_error.Monad_infix in
@@ -68,11 +68,11 @@ module Fragment_length_histogram = struct
     let open Or_error.Monad_infix in
     Bam.Alignment0.flags al
     >>= fun fl ->
-    let multi_segment = Biocaml.Sam.Flags.has_multiple_segments fl in
+    let multi_segment = Biocaml.Sam.Flag.has_multiple_segments fl in
     let each_segment_properly_aligned =
-      Biocaml.Sam.Flags.each_segment_properly_aligned fl
+      Biocaml.Sam.Flag.each_segment_properly_aligned fl
     in
-    let segment_unmapped = Biocaml.Sam.Flags.segment_unmapped fl in
+    let segment_unmapped = Biocaml.Sam.Flag.segment_unmapped fl in
     let qc_ok =
       match Bam.Alignment0.mapq al with
       | Some mapq -> mapq >= min_mapq

--- a/lib/unix/bamstats.ml
+++ b/lib/unix/bamstats.ml
@@ -1,15 +1,15 @@
 type t =
   { total : int
   ; qc_pass : int
-      (** [not_passing_quality_controls] returns [false],
+    (** [not_passing_quality_controls] returns [false],
                       assumed for all other counts *)
   ; single_reads : int (** [has_multiple_segments] returns [false] *)
   ; read_pairs : int (** [has_multiple_segments] and [first_segment] *)
   ; mapped_reads : int
-      (** [!segment_unmapped] and [!secondary_alignment]
+    (** [!segment_unmapped] and [!secondary_alignment]
                            and [!supplementary_alignment] *)
   ; mapped_pairs : int
-      (** [has_multiple_segments] and [first_segment]
+    (** [has_multiple_segments] and [first_segment]
                            and [each_segment_properly_aligned]
                            and [!secondary_alignment]
                            and [!supplementary_alignment] *)
@@ -41,15 +41,15 @@ let update_gen s flags =
     let main_mapping =
       not
         (segment_unmapped flags
-        || secondary_alignment flags
-        || supplementary_alignment flags)
+         || secondary_alignment flags
+         || supplementary_alignment flags)
     in
     let mapped_reads = incr_if main_mapping s.mapped_reads in
     let mapped_pairs = incr_if (main_mapping && pair_witness) s.mapped_pairs in
     { total; qc_pass; single_reads; read_pairs; mapped_reads; mapped_pairs })
 ;;
 
-let update s al = update_gen s al.Biocaml.Sam.flags
+let update s al = update_gen s al.Biocaml.Sam.Alignment.flags
 
 let update0 s al =
   let open Or_error.Monad_infix in

--- a/lib/unix/bamstats.mli
+++ b/lib/unix/bamstats.mli
@@ -1,15 +1,15 @@
 type t =
   { total : int
   ; qc_pass : int
-      (** [not_passing_quality_controls] returns [false],
+    (** [not_passing_quality_controls] returns [false],
                       assumed for all other counts *)
   ; single_reads : int (** [has_multiple_segments] returns [false] *)
   ; read_pairs : int (** [has_multiple_segments] and [first_segment] *)
   ; mapped_reads : int
-      (** [!segment_unmapped] and [!secondary_alignment]
+    (** [!segment_unmapped] and [!secondary_alignment]
                            and [!supplementary_alignment] *)
   ; mapped_pairs : int
-      (** [has_multiple_segments] and [first_segment]
+    (** [has_multiple_segments] and [first_segment]
                            and [each_segment_properly_aligned]
                            and [!secondary_alignment]
                            and [!supplementary_alignment] *)
@@ -18,7 +18,7 @@ type t =
 
 val zero : t
 val update0 : t -> Bam.Alignment0.t -> t Or_error.t
-val update : t -> Biocaml.Sam.alignment -> t
+val update : t -> Biocaml.Sam.Alignment.t -> t
 
 module Fragment_length_histogram : sig
   type t = private

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -12,7 +12,8 @@ module MakeIO (Future : Future.S) = struct
   end
 
   let read_header lines =
-    let rec loop hdr : Biocaml.Sam.Header.t Or_error.t Deferred.t =
+    let rec loop (hdr : Biocaml.Sam.Header.t) : Biocaml.Sam.Header.t Or_error.t Deferred.t
+      =
       Pipe.peek_deferred lines
       >>= function
       | `Eof -> return (Ok hdr)
@@ -27,10 +28,10 @@ module MakeIO (Future : Future.S) = struct
           Biocaml.Sam.Header.Item.of_string (line : Biocaml.Line.t :> string)
           |> function
           | Error _ as e -> return e
-          | Ok (`HD ({ version; sort_order; group_order } : Biocaml.Sam.Header.HD.t)) -> (
-            match hdr.Biocaml.Sam.Header.version with
+          | Ok (`HD (hd : Biocaml.Sam.Header.HD.t)) -> (
+            match hdr.Biocaml.Sam.Header.hd with
             | Some _ -> return (Or_error.error_string "multiple @HD lines not allowed")
-            | None -> loop { hdr with version = Some version; sort_order; group_order })
+            | None -> loop { hdr with hd = Some hd })
           | Ok (`SQ x) ->
             loop { hdr with ref_seqs = x :: hdr.Biocaml.Sam.Header.ref_seqs }
           | Ok (`RG x) ->
@@ -45,22 +46,13 @@ module MakeIO (Future : Future.S) = struct
     loop Biocaml.Sam.Header.empty
     >>| function
     | Error _ as e -> e
-    | Ok ({ version; sort_order; group_order; _ } as x) ->
+    | Ok ({ hd; _ } as x) ->
       let ref_seqs = List.rev x.Biocaml.Sam.Header.ref_seqs in
       let read_groups = List.rev x.Biocaml.Sam.Header.read_groups in
       let programs = List.rev x.Biocaml.Sam.Header.programs in
       let comments = List.rev x.Biocaml.Sam.Header.comments in
       let others = List.rev x.Biocaml.Sam.Header.others in
-      Biocaml.Sam.Header.make
-        ?version
-        ?sort_order
-        ?group_order
-        ~ref_seqs
-        ~read_groups
-        ~programs
-        ~comments
-        ~others
-        ()
+      Biocaml.Sam.Header.make ?hd ~ref_seqs ~read_groups ~programs ~comments ~others ()
   ;;
 
   let read ?(start = Biocaml.Pos.(incr_line unknown)) r =
@@ -85,33 +77,11 @@ module MakeIO (Future : Future.S) = struct
       Ok (hdr, alignments)
   ;;
 
-  let write_header w (h : Biocaml.Sam.Header.t) =
-    let open Writer in
-    (match h.Biocaml.Sam.Header.version with
-     | None -> Deferred.unit
-     | Some version ->
-       write_line
-         w
-         (Biocaml.Sam.Header.HD.to_string
-            { version
-            ; sort_order = h.Biocaml.Sam.Header.sort_order
-            ; group_order = h.Biocaml.Sam.Header.group_order
-            }))
-    >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.SQ.to_string x))
-    >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.RG.to_string x))
-    >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.programs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.PG.to_string x))
-    >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.comments ~f:(fun x ->
-      write w "@CO\t" >>= fun () -> write_line w x)
-    >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.others ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.Other.to_string x))
+  let write_header w (header : Biocaml.Sam.Header.t) =
+    header
+    |> Biocaml.Sam.Header.to_items
+    |> Deferred.List.iter ~how:`Sequential ~f:(fun x ->
+      Writer.write_line w (Biocaml.Sam.Header.Item.to_string x))
   ;;
 
   let write w ?(header = Biocaml.Sam.Header.empty) alignments =

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -27,10 +27,7 @@ module MakeIO (Future : Future.S) = struct
           Biocaml.Sam.Header.Header_item.parse line
           |> function
           | Error _ as e -> return e
-          | Ok
-              (`HD
-                 ({ version; sort_order; group_order } : Biocaml.Sam.Header.Header_line.t))
-            -> (
+          | Ok (`HD ({ version; sort_order; group_order } : Biocaml.Sam.Header.HD.t)) -> (
             match hdr.Biocaml.Sam.Header.version with
             | Some _ -> return (Or_error.error_string "multiple @HD lines not allowed")
             | None -> loop { hdr with version = Some version; sort_order; group_order })
@@ -95,20 +92,20 @@ module MakeIO (Future : Future.S) = struct
      | Some version ->
        write_line
          w
-         (Biocaml.Sam.Header.Header_line.print
+         (Biocaml.Sam.Header.HD.print
             { version
             ; sort_order = h.Biocaml.Sam.Header.sort_order
             ; group_order = h.Biocaml.Sam.Header.group_order
             }))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.Ref_seq.print x))
+      write_line w (Biocaml.Sam.Header.SQ.print x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.Read_group.print x))
+      write_line w (Biocaml.Sam.Header.RG.print x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.programs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.Program.print x))
+      write_line w (Biocaml.Sam.Header.PG.print x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.comments ~f:(fun x ->
       write w "@CO\t" >>= fun () -> write_line w x)

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -111,7 +111,7 @@ module MakeIO (Future : Future.S) = struct
       write w "@CO\t" >>= fun () -> write_line w x)
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.others ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.print_other x))
+      write_line w (Biocaml.Sam.Header.Other.print x))
   ;;
 
   let write w ?(header = Biocaml.Sam.Header.empty_header) alignments =

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -24,7 +24,7 @@ module MakeIO (Future : Future.S) = struct
         else
           Pipe.junk lines
           >>= fun () ->
-          Biocaml.Sam.Header.Item.t_of_line line
+          Biocaml.Sam.Header.Item.t_of_string (line : Biocaml.Line.t :> string)
           |> function
           | Error _ as e -> return e
           | Ok (`HD ({ version; sort_order; group_order } : Biocaml.Sam.Header.HD.t)) -> (
@@ -77,7 +77,7 @@ module MakeIO (Future : Future.S) = struct
       let alignments =
         Pipe.map lines ~f:(fun line ->
           Or_error.tag_arg
-            (Biocaml.Sam.Alignment.t_of_line line)
+            (Biocaml.Sam.Alignment.t_of_string (line : Biocaml.Line.t :> string))
             "position"
             !pos
             Biocaml.Pos.sexp_of_t)

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -24,7 +24,7 @@ module MakeIO (Future : Future.S) = struct
         else
           Pipe.junk lines
           >>= fun () ->
-          Biocaml.Sam.Header.Item.parse line
+          Biocaml.Sam.Header.Item.t_of_line line
           |> function
           | Error _ as e -> return e
           | Ok (`HD ({ version; sort_order; group_order } : Biocaml.Sam.Header.HD.t)) -> (
@@ -77,7 +77,7 @@ module MakeIO (Future : Future.S) = struct
       let alignments =
         Pipe.map lines ~f:(fun line ->
           Or_error.tag_arg
-            (Biocaml.Sam.Alignment.parse line)
+            (Biocaml.Sam.Alignment.t_of_line line)
             "position"
             !pos
             Biocaml.Pos.sexp_of_t)
@@ -92,32 +92,33 @@ module MakeIO (Future : Future.S) = struct
      | Some version ->
        write_line
          w
-         (Biocaml.Sam.Header.HD.print
+         (Biocaml.Sam.Header.HD.string_of_t
             { version
             ; sort_order = h.Biocaml.Sam.Header.sort_order
             ; group_order = h.Biocaml.Sam.Header.group_order
             }))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.SQ.print x))
+      write_line w (Biocaml.Sam.Header.SQ.string_of_t x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.RG.print x))
+      write_line w (Biocaml.Sam.Header.RG.string_of_t x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.programs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.PG.print x))
+      write_line w (Biocaml.Sam.Header.PG.string_of_t x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.comments ~f:(fun x ->
       write w "@CO\t" >>= fun () -> write_line w x)
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.others ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.Other.print x))
+      write_line w (Biocaml.Sam.Header.Other.string_of_t x))
   ;;
 
   let write w ?(header = Biocaml.Sam.Header.empty) alignments =
     write_header w header
     >>= fun () ->
-    Pipe.iter alignments ~f:(fun a -> Writer.write_line w (Biocaml.Sam.Alignment.print a))
+    Pipe.iter alignments ~f:(fun a ->
+      Writer.write_line w (Biocaml.Sam.Alignment.string_of_t a))
   ;;
 
   let write_file ?perm ?append file ?header alignments =

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -51,7 +51,7 @@ module MakeIO (Future : Future.S) = struct
       let programs = List.rev x.Biocaml.Sam.Header.programs in
       let comments = List.rev x.Biocaml.Sam.Header.comments in
       let others = List.rev x.Biocaml.Sam.Header.others in
-      Biocaml.Sam.Header.header
+      Biocaml.Sam.Header.make
         ?version
         ?sort_order
         ?group_order

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -24,7 +24,7 @@ module MakeIO (Future : Future.S) = struct
         else
           Pipe.junk lines
           >>= fun () ->
-          Biocaml.Sam.Header.Item.t_of_string (line : Biocaml.Line.t :> string)
+          Biocaml.Sam.Header.Item.of_string (line : Biocaml.Line.t :> string)
           |> function
           | Error _ as e -> return e
           | Ok (`HD ({ version; sort_order; group_order } : Biocaml.Sam.Header.HD.t)) -> (
@@ -77,7 +77,7 @@ module MakeIO (Future : Future.S) = struct
       let alignments =
         Pipe.map lines ~f:(fun line ->
           Or_error.tag_arg
-            (Biocaml.Sam.Alignment.t_of_string (line : Biocaml.Line.t :> string))
+            (Biocaml.Sam.Alignment.of_string (line : Biocaml.Line.t :> string))
             "position"
             !pos
             Biocaml.Pos.sexp_of_t)
@@ -92,33 +92,33 @@ module MakeIO (Future : Future.S) = struct
      | Some version ->
        write_line
          w
-         (Biocaml.Sam.Header.HD.string_of_t
+         (Biocaml.Sam.Header.HD.to_string
             { version
             ; sort_order = h.Biocaml.Sam.Header.sort_order
             ; group_order = h.Biocaml.Sam.Header.group_order
             }))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.SQ.string_of_t x))
+      write_line w (Biocaml.Sam.Header.SQ.to_string x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.RG.string_of_t x))
+      write_line w (Biocaml.Sam.Header.RG.to_string x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.programs ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.PG.string_of_t x))
+      write_line w (Biocaml.Sam.Header.PG.to_string x))
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.comments ~f:(fun x ->
       write w "@CO\t" >>= fun () -> write_line w x)
     >>= fun () ->
     Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.others ~f:(fun x ->
-      write_line w (Biocaml.Sam.Header.Other.string_of_t x))
+      write_line w (Biocaml.Sam.Header.Other.to_string x))
   ;;
 
   let write w ?(header = Biocaml.Sam.Header.empty) alignments =
     write_header w header
     >>= fun () ->
     Pipe.iter alignments ~f:(fun a ->
-      Writer.write_line w (Biocaml.Sam.Alignment.string_of_t a))
+      Writer.write_line w (Biocaml.Sam.Alignment.to_string a))
   ;;
 
   let write_file ?perm ?append file ?header alignments =

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -24,7 +24,7 @@ module MakeIO (Future : Future.S) = struct
         else
           Pipe.junk lines
           >>= fun () ->
-          Biocaml.Sam.Header.Header_item.parse line
+          Biocaml.Sam.Header.Item.parse line
           |> function
           | Error _ as e -> return e
           | Ok (`HD ({ version; sort_order; group_order } : Biocaml.Sam.Header.HD.t)) -> (

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -12,7 +12,7 @@ module MakeIO (Future : Future.S) = struct
   end
 
   let read_header lines =
-    let rec loop hdr : Biocaml.Sam.header Or_error.t Deferred.t =
+    let rec loop hdr : Biocaml.Sam.Header.t Or_error.t Deferred.t =
       Pipe.peek_deferred lines
       >>= function
       | `Eof -> return (Ok hdr)
@@ -24,32 +24,37 @@ module MakeIO (Future : Future.S) = struct
         else
           Pipe.junk lines
           >>= fun () ->
-          Biocaml.Sam.parse_header_item line
+          Biocaml.Sam.Header.Header_item.parse line
           |> function
           | Error _ as e -> return e
           | Ok
               (`HD
-                 ({ Biocaml.Sam.version; sort_order; group_order } :
-                   Biocaml.Sam.header_line)) -> (
-            match hdr.Biocaml.Sam.version with
+                 ({ version; sort_order; group_order } : Biocaml.Sam.Header.Header_line.t))
+            -> (
+            match hdr.Biocaml.Sam.Header.version with
             | Some _ -> return (Or_error.error_string "multiple @HD lines not allowed")
             | None -> loop { hdr with version = Some version; sort_order; group_order })
-          | Ok (`SQ x) -> loop { hdr with ref_seqs = x :: hdr.ref_seqs }
-          | Ok (`RG x) -> loop { hdr with read_groups = x :: hdr.read_groups }
-          | Ok (`PG x) -> loop { hdr with programs = x :: hdr.programs }
-          | Ok (`CO x) -> loop { hdr with comments = x :: hdr.comments }
-          | Ok (`Other x) -> loop { hdr with others = x :: hdr.others })
+          | Ok (`SQ x) ->
+            loop { hdr with ref_seqs = x :: hdr.Biocaml.Sam.Header.ref_seqs }
+          | Ok (`RG x) ->
+            loop { hdr with read_groups = x :: hdr.Biocaml.Sam.Header.read_groups }
+          | Ok (`PG x) ->
+            loop { hdr with programs = x :: hdr.Biocaml.Sam.Header.programs }
+          | Ok (`CO x) ->
+            loop { hdr with comments = x :: hdr.Biocaml.Sam.Header.comments }
+          | Ok (`Other x) -> loop { hdr with others = x :: hdr.Biocaml.Sam.Header.others }
+        )
     in
-    loop Biocaml.Sam.empty_header
+    loop Biocaml.Sam.Header.empty_header
     >>| function
     | Error _ as e -> e
     | Ok ({ version; sort_order; group_order; _ } as x) ->
-      let ref_seqs = List.rev x.ref_seqs in
-      let read_groups = List.rev x.read_groups in
-      let programs = List.rev x.programs in
-      let comments = List.rev x.comments in
-      let others = List.rev x.others in
-      Biocaml.Sam.header
+      let ref_seqs = List.rev x.Biocaml.Sam.Header.ref_seqs in
+      let read_groups = List.rev x.Biocaml.Sam.Header.read_groups in
+      let programs = List.rev x.Biocaml.Sam.Header.programs in
+      let comments = List.rev x.Biocaml.Sam.Header.comments in
+      let others = List.rev x.Biocaml.Sam.Header.others in
+      Biocaml.Sam.Header.header
         ?version
         ?sort_order
         ?group_order
@@ -75,7 +80,7 @@ module MakeIO (Future : Future.S) = struct
       let alignments =
         Pipe.map lines ~f:(fun line ->
           Or_error.tag_arg
-            (Biocaml.Sam.parse_alignment line)
+            (Biocaml.Sam.Alignment.parse line)
             "position"
             !pos
             Biocaml.Pos.sexp_of_t)
@@ -83,39 +88,39 @@ module MakeIO (Future : Future.S) = struct
       Ok (hdr, alignments)
   ;;
 
-  let write_header w (h : Biocaml.Sam.header) =
+  let write_header w (h : Biocaml.Sam.Header.t) =
     let open Writer in
-    (match h.version with
+    (match h.Biocaml.Sam.Header.version with
      | None -> Deferred.unit
      | Some version ->
        write_line
          w
-         (Biocaml.Sam.print_header_line
-            { Biocaml.Sam.version
-            ; sort_order = h.sort_order
-            ; group_order = h.group_order
+         (Biocaml.Sam.Header.Header_line.print
+            { version
+            ; sort_order = h.Biocaml.Sam.Header.sort_order
+            ; group_order = h.Biocaml.Sam.Header.group_order
             }))
     >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.ref_seqs ~f:(fun x ->
-      write_line w (Biocaml.Sam.print_ref_seq x))
+    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.ref_seqs ~f:(fun x ->
+      write_line w (Biocaml.Sam.Header.Ref_seq.print x))
     >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.read_groups ~f:(fun x ->
-      write_line w (Biocaml.Sam.print_read_group x))
+    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.read_groups ~f:(fun x ->
+      write_line w (Biocaml.Sam.Header.Read_group.print x))
     >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.programs ~f:(fun x ->
-      write_line w (Biocaml.Sam.print_program x))
+    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.programs ~f:(fun x ->
+      write_line w (Biocaml.Sam.Header.Program.print x))
     >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.comments ~f:(fun x ->
+    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.comments ~f:(fun x ->
       write w "@CO\t" >>= fun () -> write_line w x)
     >>= fun () ->
-    Deferred.List.iter ~how:`Sequential h.others ~f:(fun x ->
-      write_line w (Biocaml.Sam.print_other x))
+    Deferred.List.iter ~how:`Sequential h.Biocaml.Sam.Header.others ~f:(fun x ->
+      write_line w (Biocaml.Sam.Header.print_other x))
   ;;
 
-  let write w ?(header = Biocaml.Sam.empty_header) alignments =
+  let write w ?(header = Biocaml.Sam.Header.empty_header) alignments =
     write_header w header
     >>= fun () ->
-    Pipe.iter alignments ~f:(fun a -> Writer.write_line w (Biocaml.Sam.print_alignment a))
+    Pipe.iter alignments ~f:(fun a -> Writer.write_line w (Biocaml.Sam.Alignment.print a))
   ;;
 
   let write_file ?perm ?append file ?header alignments =

--- a/lib/unix/sam.ml
+++ b/lib/unix/sam.ml
@@ -42,7 +42,7 @@ module MakeIO (Future : Future.S) = struct
           | Ok (`Other x) -> loop { hdr with others = x :: hdr.Biocaml.Sam.Header.others }
         )
     in
-    loop Biocaml.Sam.Header.empty_header
+    loop Biocaml.Sam.Header.empty
     >>| function
     | Error _ as e -> e
     | Ok ({ version; sort_order; group_order; _ } as x) ->
@@ -114,7 +114,7 @@ module MakeIO (Future : Future.S) = struct
       write_line w (Biocaml.Sam.Header.Other.print x))
   ;;
 
-  let write w ?(header = Biocaml.Sam.Header.empty_header) alignments =
+  let write w ?(header = Biocaml.Sam.Header.empty) alignments =
     write_header w header
     >>= fun () ->
     Pipe.iter alignments ~f:(fun a -> Writer.write_line w (Biocaml.Sam.Alignment.print a))

--- a/lib/unix/sam.mli
+++ b/lib/unix/sam.mli
@@ -13,24 +13,25 @@ module MakeIO (Future : Future.S) : sig
   val read
     :  ?start:Biocaml.Pos.t
     -> Reader.t
-    -> (Biocaml.Sam.header * Biocaml.Sam.alignment Or_error.t Pipe.Reader.t) Or_error.t
-       Deferred.t
+    -> (Biocaml.Sam.Header.t * Biocaml.Sam.Alignment.t Or_error.t Pipe.Reader.t)
+         Or_error.t
+         Deferred.t
 
   val write
     :  Writer.t
-    -> ?header:Biocaml.Sam.header
-    -> Biocaml.Sam.alignment Pipe.Reader.t
+    -> ?header:Biocaml.Sam.Header.t
+    -> Biocaml.Sam.Alignment.t Pipe.Reader.t
     -> unit Deferred.t
 
   val write_file
     :  ?perm:int
     -> ?append:bool
     -> string
-    -> ?header:Biocaml.Sam.header
-    -> Biocaml.Sam.alignment Pipe.Reader.t
+    -> ?header:Biocaml.Sam.Header.t
+    -> Biocaml.Sam.Alignment.t Pipe.Reader.t
     -> unit Deferred.t
 end
 
 include module type of MakeIO (Future_unix)
 
-val parse_header : string -> Biocaml.Sam.header Or_error.t
+val parse_header : string -> Biocaml.Sam.Header.t Or_error.t


### PR DESCRIPTION
Tasks:
- [x] Every type organized into its own submodule. Corresponding functions moved into those submodules.
~- [ ] Defined a new `State` module with a `reduce` function.~
~- [ ] Delete `Sam` module from unix/lwt/async versions of the library. The new pure `Sam.reduce` provides sufficient convenience that these no longer add value.~